### PR TITLE
Otp screen UI ready. 

### DIFF
--- a/MomCare/Controllers/OTPScreenViewController.swift
+++ b/MomCare/Controllers/OTPScreenViewController.swift
@@ -1,0 +1,20 @@
+//
+//  OTPScreenViewController.swift
+//  MomCare
+//
+//  Created by RITIK RANJAN on 08/06/25.
+//
+
+import SwiftUI
+
+class OTPScreenViewController: UIHostingController<OTPScreen> {
+
+    init() {
+        super.init(rootView: OTPScreen())
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/MomCare/StoryBoards/Others/OTPScreen.storyboard
+++ b/MomCare/StoryBoards/Others/OTPScreen.storyboard
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CEq-IK-zZV">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+    </dependencies>
+    <scenes>
+        <!--Hosting Controller-->
+        <scene sceneID="U1u-EP-X3H">
+            <objects>
+                <hostingController id="CEq-IK-zZV" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="U2A-58-1Ds" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="216" y="6"/>
+        </scene>
+    </scenes>
+</document>

--- a/MomCare/SwiftUI/OTPScreen.swift
+++ b/MomCare/SwiftUI/OTPScreen.swift
@@ -1,5 +1,5 @@
 //
-//  otpScreen.swift
+//  OTPScreen.swift
 //  MomCare
 //
 //  Created by Aryan Singh on 08/06/25.
@@ -8,7 +8,7 @@
 import SwiftUI
 import Combine
 
-struct otpScreen: View {
+struct OTPScreen: View {
     @State private var otpString: String = ""
     @FocusState private var isFieldFocused: Bool
     private let otpLength = 6
@@ -28,7 +28,6 @@ struct otpScreen: View {
                     .padding(.horizontal)
             }
             
-            // OTP Input Field
             ZStack(alignment: .center) {
                 HStack(spacing: 12) {
                     ForEach(0..<otpLength, id: \.self) { index in
@@ -40,7 +39,6 @@ struct otpScreen: View {
                     }
                 }
                 
-                // Actual input field (invisible)
                 TextField("", text: $otpString)
                     .frame(width: 1, height: 1)
                     .opacity(0.01)
@@ -48,17 +46,13 @@ struct otpScreen: View {
                     .textContentType(.oneTimeCode)
                     .focused($isFieldFocused)
                     .onChange(of: otpString) { _, newValue in
-                        // Limit to maximum length
                         if newValue.count > otpLength {
                             otpString = String(newValue.prefix(otpLength))
                         }
                         
-                        // Filter to numbers only
                         otpString = newValue.filter { "0123456789".contains($0) }
                     }
                     .onAppear {
-                        // Making this optional since SMS autofill might make it unnecessary
-                        // but keeping it as a fallback for when autofill doesn't happen
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             isFieldFocused = true
                         }
@@ -107,18 +101,15 @@ struct otpScreen: View {
     }
 }
 
-// A visual box for displaying one digit of the OTP
 struct OTPBox: View {
     let index: Int
     let otpString: String
     let isActive: Bool
     
-    // Cursor blinking state
     @State private var showCursor = false
     
     var body: some View {
         ZStack {
-            // Box
             RoundedRectangle(cornerRadius: 8)
                 .stroke(isActive ? Color(hex: "924350") : Color.gray.opacity(0.3), lineWidth: isActive ? 2 : 1)
                 .background(
@@ -126,15 +117,12 @@ struct OTPBox: View {
                         .fill(Color(.systemBackground))
                 )
             
-            // Text or cursor
             if index < otpString.count {
-                // Show the digit
                 let startIndex = otpString.startIndex
                 let charIndex = otpString.index(startIndex, offsetBy: index)
                 Text(String(otpString[charIndex]))
                     .font(.title2.weight(.semibold))
             } else if isActive {
-                // Show blinking cursor
                 Rectangle()
                     .fill(Color(hex: "924350"))
                     .frame(width: 2, height: 24)
@@ -147,8 +135,4 @@ struct OTPBox: View {
         }
         .frame(width: 45, height: 55)
     }
-}
-
-#Preview {
-    otpScreen()
 }

--- a/MomCare/SwiftUI/otpScreen.swift
+++ b/MomCare/SwiftUI/otpScreen.swift
@@ -45,6 +45,7 @@ struct otpScreen: View {
                     .frame(width: 1, height: 1)
                     .opacity(0.01)
                     .keyboardType(.numberPad)
+                    .textContentType(.oneTimeCode)
                     .focused($isFieldFocused)
                     .onChange(of: otpString) { _, newValue in
                         // Limit to maximum length
@@ -56,6 +57,8 @@ struct otpScreen: View {
                         otpString = newValue.filter { "0123456789".contains($0) }
                     }
                     .onAppear {
+                        // Making this optional since SMS autofill might make it unnecessary
+                        // but keeping it as a fallback for when autofill doesn't happen
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                             isFieldFocused = true
                         }

--- a/MomCare/SwiftUI/otpScreen.swift
+++ b/MomCare/SwiftUI/otpScreen.swift
@@ -1,0 +1,150 @@
+//
+//  otpScreen.swift
+//  MomCare
+//
+//  Created by Aryan Singh on 08/06/25.
+//
+
+import SwiftUI
+import Combine
+
+struct otpScreen: View {
+    @State private var otpString: String = ""
+    @FocusState private var isFieldFocused: Bool
+    private let otpLength = 6
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 8) {
+                Text("Verification Code")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .padding(.top)
+                
+                Text("Enter the code we sent to your phone number")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            }
+            
+            // OTP Input Field
+            ZStack(alignment: .center) {
+                HStack(spacing: 12) {
+                    ForEach(0..<otpLength, id: \.self) { index in
+                        OTPBox(
+                            index: index, 
+                            otpString: otpString,
+                            isActive: isFieldFocused && index == otpString.count
+                        )
+                    }
+                }
+                
+                // Actual input field (invisible)
+                    .frame(width: 1, height: 1)
+                    .opacity(0.01)
+                    .keyboardType(.numberPad)
+                    .focused($isFieldFocused)
+                    .onChange(of: otpString) { _, newValue in
+                        // Limit to maximum length
+                        if newValue.count > otpLength {
+                            otpString = String(newValue.prefix(otpLength))
+                        }
+                        
+                        // Filter to numbers only
+                        otpString = newValue.filter { "0123456789".contains($0) }
+                    }
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                            isFieldFocused = true
+                        }
+                    }
+            }
+            .padding(.horizontal)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isFieldFocused = true
+            }
+            Button(action: verifyOTP) {
+                Text("Verify")
+                    .fontWeight(.semibold)
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isOTPComplete() ? Color(hex: "924350") : Color.gray.opacity(0.3))
+                    .foregroundColor(.white)
+                    .cornerRadius(14)
+            }
+            .padding(.horizontal, 24)
+            .disabled(!isOTPComplete())
+
+            Button(action: resendCode) {
+                Text("Didn't receive a code?")
+                    .foregroundColor(Color(hex: "924350"))
+                    .padding(.top)
+            }
+            
+            Spacer()
+        }
+        .padding()
+    }
+    
+    private func isOTPComplete() -> Bool {
+        return otpString.count == otpLength
+    }
+    
+    private func verifyOTP() {
+        print("OTP Verification requested with code: \(otpString)")
+        // Here you would add your verification logic
+    }
+    
+    private func resendCode() {
+        print("Resend code requested")
+        // Here you would add your resend logic
+    }
+}
+
+// A visual box for displaying one digit of the OTP
+struct OTPBox: View {
+    let index: Int
+    let otpString: String
+    let isActive: Bool
+    
+    // Cursor blinking state
+    @State private var showCursor = false
+    
+    var body: some View {
+        ZStack {
+            // Box
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(isActive ? Color(hex: "924350") : Color.gray.opacity(0.3), lineWidth: isActive ? 2 : 1)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color(.systemBackground))
+                )
+            
+            // Text or cursor
+            if index < otpString.count {
+                // Show the digit
+                let startIndex = otpString.startIndex
+                let charIndex = otpString.index(startIndex, offsetBy: index)
+                Text(String(otpString[charIndex]))
+                    .font(.title2.weight(.semibold))
+            } else if isActive {
+                // Show blinking cursor
+                Rectangle()
+                    .fill(Color(hex: "924350"))
+                    .frame(width: 2, height: 24)
+                    .opacity(showCursor ? 1 : 0)
+                    .animation(Animation.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: showCursor)
+                    .onAppear {
+                        showCursor = true
+                    }
+            }
+        }
+        .frame(width: 45, height: 55)
+    }
+}
+
+#Preview {
+    otpScreen()
+}

--- a/MomCare/SwiftUI/otpScreen.swift
+++ b/MomCare/SwiftUI/otpScreen.swift
@@ -41,6 +41,7 @@ struct otpScreen: View {
                 }
                 
                 // Actual input field (invisible)
+                TextField("", text: $otpString)
                     .frame(width: 1, height: 1)
                     .opacity(0.01)
                     .keyboardType(.numberPad)


### PR DESCRIPTION
otp screen UI is ready. it follows verification by mobile number but can be done by email also.

## Summary by Sourcery

Add a new SwiftUI OTP verification screen with six-digit input fields, blinking cursor, and verify/resend actions.

New Features:
- Introduce otpScreen view to display a six-digit OTP input interface with auto-focus and number-only entry.
- Implement OTPBox subview to render individual digit boxes with active-state styling and a blinking cursor.
- Add Verify button that activates when the OTP is complete and a Resend Code button for retrying code delivery.