### PR TITLE
Add Health Profile Cell Table View Controller

### DIFF
--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
@@ -8,39 +8,60 @@
 import UIKit
 
 class HealthDetailsCellTableViewController: UITableViewController {
-
-    @IBOutlet weak var HealthDetailLabel: UILabel!
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-    }
-    
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
+    var healthProfile: HealthProfileType?
+    var selectedIndices: Set<Int> = []
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return PreExistingCondition.allCases.count
-    }
-    
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // Dequeue a reusable cell
-        let cell = tableView.dequeueReusableCell(withIdentifier: "HealthDetailCell", for: indexPath)
-        
-        let preExistingCondition = PreExistingCondition.allCases
-        // Set the data
-        cell.HealthDetailLabel?.text = preExistingCondition[indexPath.row]
+     var stringList: [String] {
+         switch healthProfile {
+         case .preExistingCondition:
+             return PreExistingCondition.allCases.map { $0.rawValue }
+         case .intolerance:
+             return Intolerance.allCases.map { $0.rawValue }
+         case .dietaryPreference:
+             return DietaryPreference.allCases.map { $0.rawValue }
+         case .none:
+             return []
+         }
+     }
 
-        return cell
-    }
+     override func viewDidLoad() {
+         super.viewDidLoad()
+         self.title = titleForListType()
+     }
 
+     func titleForListType() -> String {
+         switch healthProfile {
+         case .preExistingCondition: return "Pre-Existing Conditions"
+         case .intolerance: return "Intolerances"
+         case .dietaryPreference: return "Dietary Preferences"
+         case .none: return ""
+         }
+     }
+
+     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+         return stringList.count
+     }
+
+     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+         let cell = tableView.dequeueReusableCell(withIdentifier: "HealthDetailCell", for: indexPath)
+         cell.textLabel?.text = stringList[indexPath.row]
+         
+         cell.accessoryType = selectedIndices.contains(indexPath.row) ? .checkmark : .none
+         
+         return cell
+     }
     
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let cell = tableView.cellForRow(at: indexPath) {
-            cell.accessoryType = (cell.accessoryType == .checkmark) ? .none : .checkmark
-        }
-    }
+        tableView.deselectRow(at: indexPath, animated: true)
 
+        if selectedIndices.contains(indexPath.row) {
+            selectedIndices.remove(indexPath.row)
+        } else {
+            selectedIndices.insert(indexPath.row)
+        }
+
+        tableView.reloadRows(at: [indexPath], with: .automatic)
+    }
 
 }

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
@@ -10,9 +10,9 @@ import UIKit
 class HealthDetailsCellTableViewController: UITableViewController {
     
     var healthProfile: HealthProfileType?
-    var selectedIndices: Set<Int> = []
+    var selectedCells: Set<Int> = []
 
-     var stringList: [String] {
+     var healthList: [String] {
          switch healthProfile {
          case .preExistingCondition:
              return PreExistingCondition.allCases.map { $0.rawValue }
@@ -27,10 +27,10 @@ class HealthDetailsCellTableViewController: UITableViewController {
 
      override func viewDidLoad() {
          super.viewDidLoad()
-         self.title = titleForListType()
+         self.title = healthListtitle()
      }
 
-     func titleForListType() -> String {
+     func healthListtitle() -> String {
          switch healthProfile {
          case .preExistingCondition: return "Pre-Existing Conditions"
          case .intolerance: return "Intolerances"
@@ -40,14 +40,14 @@ class HealthDetailsCellTableViewController: UITableViewController {
      }
 
      override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-         return stringList.count
+         return healthList.count
      }
 
      override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
          let cell = tableView.dequeueReusableCell(withIdentifier: "HealthDetailCell", for: indexPath)
-         cell.textLabel?.text = stringList[indexPath.row]
+         cell.textLabel?.text = healthList[indexPath.row]
          
-         cell.accessoryType = selectedIndices.contains(indexPath.row) ? .checkmark : .none
+         cell.accessoryType = selectedCells.contains(indexPath.row) ? .checkmark : .none
          
          return cell
      }
@@ -55,10 +55,10 @@ class HealthDetailsCellTableViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
 
-        if selectedIndices.contains(indexPath.row) {
-            selectedIndices.remove(indexPath.row)
+        if selectedCells.contains(indexPath.row) {
+            selectedCells.remove(indexPath.row)
         } else {
-            selectedIndices.insert(indexPath.row)
+            selectedCells.insert(indexPath.row)
         }
 
         tableView.reloadRows(at: [indexPath], with: .automatic)

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
@@ -49,7 +49,26 @@ class HealthDetailsTableViewController: UITableViewController {
     func saveHealtghDetails(){
         
     }
-        
+    
+    @IBAction func preExistingTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.preExistingCondition)
+    }
+
+    @IBAction func intoleranceTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.intolerance)
+    }
+
+    @IBAction func dietaryTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.dietaryPreference)
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "showUserHealthProfile",
+           let destination = segue.destination as? HealthDetailsCellTableViewController,
+           let type = sender as? HealthProfileType {
+            destination.healthProfile = type
+        }
+    }
     
 }
 

--- a/MomCare/DataModels/UserModel.swift
+++ b/MomCare/DataModels/UserModel.swift
@@ -40,6 +40,12 @@ public enum DietaryPreference: String, Codable, CaseIterable, Sendable {
     case dairyFree = "Dairy-Free"
 }
 
+enum HealthProfileType {
+    case preExistingCondition
+    case intolerance
+    case dietaryPreference
+}
+
 public enum MoodType: String, Codable, Sendable {
    case happy = "Happy"
    case sad = "Sad"

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -535,7 +535,7 @@
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <segue destination="MeX-Vk-bHc" kind="show" id="gPp-Zd-jVd"/>
+                                                                <action selector="preExistingTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="jDp-qk-aU5"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
@@ -575,6 +575,9 @@
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
+                                                            <connections>
+                                                                <action selector="dietaryTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="0Xj-k2-aSe"/>
+                                                            </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
@@ -613,6 +616,9 @@
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
+                                                            <connections>
+                                                                <action selector="intoleranceTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="ymT-8y-oXc"/>
+                                                            </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
@@ -641,6 +647,7 @@
                         <outlet property="userDietaryPreferences" destination="yFy-ha-quh" id="ASd-SR-4oA"/>
                         <outlet property="userDueDate" destination="kTv-3b-yXS" id="9h4-8I-HJ9"/>
                         <outlet property="userMedicalConditions" destination="1ju-Dr-mx1" id="k2s-HH-TMY"/>
+                        <segue destination="MeX-Vk-bHc" kind="show" identifier="showUserHealthProfile" id="MBx-pL-pc1"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IuO-CW-qz4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -655,7 +662,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wtj-qF-QJD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2317" y="944"/>
+            <point key="canvasLocation" x="2317" y="984"/>
         </scene>
         <!--Personal Info-->
         <scene sceneID="iRU-kW-izF">

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -662,7 +662,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wtj-qF-QJD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2317" y="984"/>
+            <point key="canvasLocation" x="2317" y="947"/>
         </scene>
         <!--Personal Info-->
         <scene sceneID="iRU-kW-izF">

--- a/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/HealthDetailsCellsStoryboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/HealthDetailsCellsStoryboard.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="1yC-bw-Thk">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23727"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -20,19 +20,6 @@
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Oib-W0-22A" id="4Mi-t9-Ynf">
                                     <rect key="frame" x="0.0" y="0.0" width="353" height="53"/>
                                     <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MP2-kh-lfc">
-                                            <rect key="frame" x="27" y="16" width="42" height="21"/>
-                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="bottomMargin" secondItem="MP2-kh-lfc" secondAttribute="bottom" constant="5" id="2fu-dm-zKb"/>
-                                        <constraint firstItem="MP2-kh-lfc" firstAttribute="top" secondItem="4Mi-t9-Ynf" secondAttribute="topMargin" constant="5" id="Nqw-rx-AuU"/>
-                                        <constraint firstItem="MP2-kh-lfc" firstAttribute="leading" secondItem="4Mi-t9-Ynf" secondAttribute="leadingMargin" constant="7" id="Y0O-hg-MqK"/>
-                                    </constraints>
                                 </tableViewCellContentView>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableViewCell>
@@ -43,9 +30,6 @@
                             <outlet property="delegate" destination="1yC-bw-Thk" id="G43-1B-s27"/>
                         </connections>
                     </tableView>
-                    <connections>
-                        <outlet property="HealthDetailLabel" destination="MP2-kh-lfc" id="fHm-s1-rGl"/>
-                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tJ8-lr-hjo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
- Add HealthProfileCellTableViewController
- Edit HealthProfileTableViewController
- Add Storyboard reference id
**Missing is data passing/fetching from signUpPage/MongoDB**

## Summary by Sourcery

Introduce a new health profile cell view for selecting user health details, enhance personal and health details controllers with edit/save workflows, and clean up obsolete controllers.

New Features:
- Add HealthDetailsCellTableViewController to display selectable health profile items
- Add HealthDetailsTableViewController with edit/save mode and navigation to health profile cells
- Implement async saveUser in PersonalDetailsTableViewController to persist name, DOB, height, and weight from UI

Enhancements:
- Rename and refactor PersonalInfoTableViewController to PersonalDetailsTableViewController and move picker logic into an extension
- Introduce HealthProfileType enum to distinguish between pre-existing conditions, intolerances, and dietary preferences
- Update storyboards to include a new HealthDetailsCell storyboard for health profile selection

Chores:
- Remove deprecated HealthPreferencesTableViewController, PrivacyTableViewController, and SettingsTableViewController