### PR TITLE
HealthDetailProfileSection Fix

### DIFF
--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsCellTableViewController.swift
@@ -8,23 +8,60 @@
 import UIKit
 
 class HealthDetailsCellTableViewController: UITableViewController {
+    
+    var healthProfile: HealthProfileType?
+    var selectedCells: Set<Int> = []
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
-    }
+     var healthList: [String] {
+         switch healthProfile {
+         case .preExistingCondition:
+             return PreExistingCondition.allCases.map { $0.rawValue }
+         case .intolerance:
+             return Intolerance.allCases.map { $0.rawValue }
+         case .dietaryPreference:
+             return DietaryPreference.allCases.map { $0.rawValue }
+         case .none:
+             return []
+         }
+     }
 
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return PreExistingCondition.allCases.count
-    }
+     override func viewDidLoad() {
+         super.viewDidLoad()
+         self.title = healthListtitle()
+     }
 
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return tableView.dequeueReusableCell(withIdentifier: "HealthDetailCell", for: indexPath)
-    }
+     func healthListtitle() -> String {
+         switch healthProfile {
+         case .preExistingCondition: return "Pre-Existing Conditions"
+         case .intolerance: return "Intolerances"
+         case .dietaryPreference: return "Dietary Preferences"
+         case .none: return ""
+         }
+     }
 
+     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+         return healthList.count
+     }
+
+     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+         let cell = tableView.dequeueReusableCell(withIdentifier: "HealthDetailCell", for: indexPath)
+         cell.textLabel?.text = healthList[indexPath.row]
+         
+         cell.accessoryType = selectedCells.contains(indexPath.row) ? .checkmark : .none
+         
+         return cell
+     }
+    
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if let cell = tableView.cellForRow(at: indexPath) {
-            cell.accessoryType = (cell.accessoryType == .checkmark) ? .none : .checkmark
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        if selectedCells.contains(indexPath.row) {
+            selectedCells.remove(indexPath.row)
+        } else {
+            selectedCells.insert(indexPath.row)
         }
+
+        tableView.reloadRows(at: [indexPath], with: .automatic)
     }
 
 }

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
@@ -47,5 +47,24 @@ class HealthDetailsTableViewController: UITableViewController {
     }
 
     func saveHealtghDetails() {}
+    
+    @IBAction func preExistingTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.preExistingCondition)
+    }
 
+    @IBAction func intoleranceTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.intolerance)
+    }
+
+    @IBAction func dietaryTapped(_ sender: UIButton) {
+        performSegue(withIdentifier: "showUserHealthProfile", sender: HealthProfileType.dietaryPreference)
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if segue.identifier == "showUserHealthProfile",
+           let destination = segue.destination as? HealthDetailsCellTableViewController,
+           let type = sender as? HealthProfileType {
+            destination.healthProfile = type
+        }
+    }
 }

--- a/MomCare/DataModels/UserModel.swift
+++ b/MomCare/DataModels/UserModel.swift
@@ -40,6 +40,12 @@ public enum DietaryPreference: String, Codable, CaseIterable, Sendable {
     case dairyFree = "Dairy-Free"
 }
 
+enum HealthProfileType {
+    case preExistingCondition
+    case intolerance
+    case dietaryPreference
+}
+
 public enum MoodType: String, Codable, Sendable {
    case happy = "Happy"
    case sad = "Sad"

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -624,7 +624,7 @@
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <segue destination="MeX-Vk-bHc" kind="show" id="gPp-Zd-jVd"/>
+                                                                <action selector="preExistingTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="wYv-CD-0DU"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
@@ -664,6 +664,9 @@
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
+                                                            <connections>
+                                                                <action selector="dietaryTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="Rpb-PO-VQg"/>
+                                                            </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
@@ -702,6 +705,9 @@
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                             </buttonConfiguration>
+                                                            <connections>
+                                                                <action selector="intoleranceTapped:" destination="Fti-hv-RJM" eventType="touchUpInside" id="Kvk-v6-KiB"/>
+                                                            </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
@@ -730,6 +736,7 @@
                         <outlet property="userDietaryPreferences" destination="yFy-ha-quh" id="ASd-SR-4oA"/>
                         <outlet property="userDueDate" destination="kTv-3b-yXS" id="9h4-8I-HJ9"/>
                         <outlet property="userMedicalConditions" destination="1ju-Dr-mx1" id="k2s-HH-TMY"/>
+                        <segue destination="MeX-Vk-bHc" kind="show" identifier="showUserHealthProfile" id="HDl-Mm-txa"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="IuO-CW-qz4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
Add HealthCellTableViewController
Edit HealthTableViewController
BlueCheckMark for select/deselect option

**need to pass data from signupStoryboard or fetch data from backend MongoDB in HealthCellTableViewController**

## Summary by Sourcery

Implement dynamic health detail selection flow by introducing profile type routing, multi-select lists, and checkmark support

New Features:
- Introduce HealthProfileType enum for distinguishing health profile categories
- Add button actions and segues in HealthDetailsTableViewController to navigate to detailed lists
- Enable multi-selection of health options with checkmarks in HealthDetailsCellTableViewController

Enhancements:
- Dynamically generate table titles and cell contents based on the selected health profile