### PR TITLE
MyPlan Exercise Tab UI Fix

### DIFF
--- a/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
@@ -68,17 +68,9 @@ class ExerciseViewController: UIViewController, UICollectionViewDelegate, UIColl
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        switch indexPath.item {
-        case 0:
-            return CGSize(width: 365, height: 103)
-
-        case 1:
-            return CGSize(width: 365, height: 100)
-
-        default:
-            return CGSize(width: 365, height: 170)
-        }
-
+        let width = collectionView.bounds.width - 40
+        let height: CGFloat = 105
+        return CGSize(width: width, height: height)
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseCell.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -96,14 +96,17 @@
                         </subviews>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kPS-5A-zx9">
-                        <rect key="frame" x="332" y="20" width="7" height="7"/>
+                        <rect key="frame" x="314" y="5" width="35" height="35"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="7" id="HaN-8R-i08"/>
-                            <constraint firstAttribute="width" constant="7" id="pik-AB-YMC"/>
+                            <constraint firstAttribute="height" constant="35" id="HaN-8R-i08"/>
+                            <constraint firstAttribute="width" constant="35" id="pik-AB-YMC"/>
                         </constraints>
-                        <color key="tintColor" red="0.32549019607843138" green="0.34509803921568627" blue="0.37254901960784315" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="tintColor" red="0.32549019610000002" green="0.34509803919999998" blue="0.37254901959999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <state key="normal" title="Button"/>
-                        <buttonConfiguration key="configuration" style="plain" image="info.circle.fill" catalog="system"/>
+                        <buttonConfiguration key="configuration" style="filled" image="info.circle.fill" catalog="system">
+                            <color key="baseForegroundColor" red="0.32549019610000002" green="0.34509803919999998" blue="0.37254901959999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <color key="baseBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </buttonConfiguration>
                         <connections>
                             <action selector="infoButtonTapped:" destination="j7w-9J-cDZ" eventType="touchUpInside" id="tND-gI-PkX"/>
                         </connections>
@@ -112,12 +115,12 @@
                 <constraints>
                     <constraint firstItem="akJ-rk-Qjc" firstAttribute="top" secondItem="JTZ-Un-ujN" secondAttribute="top" constant="5" id="69D-St-hoo"/>
                     <constraint firstItem="DCx-HD-2pe" firstAttribute="leading" secondItem="JTZ-Un-ujN" secondAttribute="leading" constant="20" id="9AP-u0-dB3"/>
-                    <constraint firstAttribute="trailing" secondItem="kPS-5A-zx9" secondAttribute="trailing" constant="20" id="9OU-3Y-cDF"/>
+                    <constraint firstAttribute="trailing" secondItem="kPS-5A-zx9" secondAttribute="trailing" constant="10" id="9OU-3Y-cDF"/>
                     <constraint firstAttribute="bottom" secondItem="akJ-rk-Qjc" secondAttribute="bottom" constant="5" id="Dr5-U6-WON"/>
                     <constraint firstItem="DCx-HD-2pe" firstAttribute="top" secondItem="JTZ-Un-ujN" secondAttribute="top" constant="20" id="Goy-4a-FLh"/>
                     <constraint firstAttribute="bottom" secondItem="DCx-HD-2pe" secondAttribute="bottom" constant="20" id="Jb7-yj-hma"/>
                     <constraint firstAttribute="trailing" secondItem="akJ-rk-Qjc" secondAttribute="trailing" constant="10" id="QFg-Uc-Fqc"/>
-                    <constraint firstItem="kPS-5A-zx9" firstAttribute="top" secondItem="JTZ-Un-ujN" secondAttribute="top" constant="20" id="zGk-4d-KCo"/>
+                    <constraint firstItem="kPS-5A-zx9" firstAttribute="top" secondItem="JTZ-Un-ujN" secondAttribute="top" constant="5" id="zGk-4d-KCo"/>
                 </constraints>
             </collectionViewCellContentView>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -135,14 +138,14 @@
                 <outlet property="exerciseStartButton" destination="A0q-ws-QUv" id="rdu-at-ovA"/>
                 <outlet property="exerciseTime" destination="aQA-b1-cOt" id="AIN-8Y-5tr"/>
             </connections>
-            <point key="canvasLocation" x="91" y="-55"/>
+            <point key="canvasLocation" x="90.839694656488547" y="-55.633802816901408"/>
         </collectionViewCell>
     </objects>
     <resources>
         <image name="Stretching" width="1440" height="1920"/>
         <image name="info.circle.fill" catalog="system" width="128" height="123"/>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseDateCell.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseDateCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -13,136 +13,136 @@
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" id="WZf-zl-hy4" customClass="ExerciseDateCellCollectionViewCell" customModule="MomCare" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="370" height="103"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" insetsLayoutMarginsFromSafeArea="NO" id="yq1-ed-KzG">
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yq1-ed-KzG">
                 <rect key="frame" x="0.0" y="0.0" width="370" height="103"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="4ax-XF-OSs">
-                        <rect key="frame" x="13" y="15" width="344" height="88"/>
+                    <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="4ax-XF-OSs">
+                        <rect key="frame" x="30" y="10" width="310" height="83"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="zoF-xn-Mtm">
-                                <rect key="frame" x="0.0" y="0.0" width="344" height="41.666666666666664"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="zoF-xn-Mtm">
+                                <rect key="frame" x="0.0" y="0.0" width="310" height="77.666666666666671"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="miF-Xy-KkQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="49" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="miF-Xy-KkQ">
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iB0-A4-Y02">
-                                                <rect key="frame" x="0.0" y="0.0" width="49" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ftP-Qq-Hsq">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="EeX-EV-uED">
-                                        <rect key="frame" x="49" y="0.0" width="49.333333333333343" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EeX-EV-uED">
+                                        <rect key="frame" x="50" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="M" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CvL-Gh-4yM">
-                                                <rect key="frame" x="0.0" y="0.0" width="49.333333333333336" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Vl-ul-h0d">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49.333333333333336" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="OUo-LS-QAH">
-                                        <rect key="frame" x="98.333333333333329" y="0.0" width="48.999999999999986" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="OUo-LS-QAH">
+                                        <rect key="frame" x="100" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="T" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5EF-bc-Rf7">
-                                                <rect key="frame" x="0.0" y="0.0" width="49" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="beu-mT-CwD">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="RRQ-WA-vbq">
-                                        <rect key="frame" x="147.33333333333334" y="0.0" width="49.333333333333343" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RRQ-WA-vbq">
+                                        <rect key="frame" x="150" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="W" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T8W-CK-yo9">
-                                                <rect key="frame" x="0.0" y="0.0" width="49.333333333333336" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8f-Qt-p0J">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49.333333333333336" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xVj-s2-9bI">
-                                        <rect key="frame" x="196.66666666666666" y="0.0" width="49" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="xVj-s2-9bI">
+                                        <rect key="frame" x="200" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="T" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TLd-h9-wz2">
-                                                <rect key="frame" x="0.0" y="0.0" width="49" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TS3-la-B5a">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hT3-hN-BdS">
-                                        <rect key="frame" x="245.66666666666671" y="0.0" width="49.333333333333343" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="hT3-hN-BdS">
+                                        <rect key="frame" x="250" y="0.0" width="50" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="F" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SZu-Hg-Fk4">
-                                                <rect key="frame" x="0.0" y="0.0" width="49.333333333333336" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wDf-27-3AR">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49.333333333333336" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="c52-OA-Zep">
-                                        <rect key="frame" x="295" y="0.0" width="49" height="41.666666666666664"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="c52-OA-Zep">
+                                        <rect key="frame" x="300" y="0.0" width="10" height="77.666666666666671"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FmW-Cs-MH9">
-                                                <rect key="frame" x="0.0" y="0.0" width="49" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="10" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GdD-Is-Znt">
-                                                <rect key="frame" x="0.0" y="25.333333333333336" width="49" height="16.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333332" width="10" height="55.333333333333343"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleAspectFill" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="xdn-FK-3rd">
-                                <rect key="frame" x="0.0" y="46.666666666666657" width="344" height="41.333333333333343"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xdn-FK-3rd">
+                                <rect key="frame" x="0.0" y="79.666666666666671" width="310" height="3.3333333333333286"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="qab-mg-Cga">
-                                        <rect key="frame" x="0.0" y="0.0" width="131.33333333333334" height="41.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="131.33333333333334" height="3.3333333333333335"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Total Goal:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Neu-Kk-xci">
-                                                <rect key="frame" x="0.0" y="0.0" width="84.333333333333329" height="41.333333333333336"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="84.333333333333329" height="3.3333333333333335"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10/30" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fcF-o1-wAe">
-                                                <rect key="frame" x="88.333333333333329" y="0.0" width="42.999999999999986" height="41.333333333333336"/>
+                                                <rect key="frame" x="88.333333333333329" y="0.0" width="42.999999999999986" height="3.3333333333333335"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -150,14 +150,14 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mAa-iY-HPI">
-                                        <rect key="frame" x="156.33333333333337" y="0.0" width="187.66666666666663" height="41.333333333333336"/>
+                                        <rect key="frame" x="147.33333333333337" y="0.0" width="162.66666666666663" height="3.3333333333333335"/>
                                         <subviews>
                                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="duN-cg-sfO">
-                                                <rect key="frame" x="0.0" y="18.666666666666664" width="136.33333333333334" height="4"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="111.33333333333333" height="3.3333333333333335"/>
                                                 <color key="tintColor" red="0.23137254901960785" green="0.27843137254901962" blue="0.32941176470588235" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             </progressView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8vA-3b-HKh">
-                                                <rect key="frame" x="144.33333333333334" y="10.333333333333334" width="43.333333333333343" height="20.333333333333329"/>
+                                                <rect key="frame" x="119.33333333333333" y="0.0" width="43.333333333333329" height="3.3333333333333335"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -167,18 +167,14 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="88" id="MrJ-AU-21i"/>
-                            <constraint firstAttribute="width" constant="344" id="rig-aP-I0n"/>
-                        </constraints>
                     </stackView>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstAttribute="bottom" secondItem="4ax-XF-OSs" secondAttribute="bottom" id="6sh-82-iV0"/>
-                    <constraint firstAttribute="trailing" secondItem="4ax-XF-OSs" secondAttribute="trailing" constant="13" id="CEp-C3-ECM"/>
-                    <constraint firstItem="4ax-XF-OSs" firstAttribute="top" secondItem="yq1-ed-KzG" secondAttribute="top" constant="15" id="mPe-Al-kqD"/>
-                    <constraint firstItem="4ax-XF-OSs" firstAttribute="leading" secondItem="yq1-ed-KzG" secondAttribute="leading" constant="13" id="sfz-C0-Bcl"/>
+                    <constraint firstItem="4ax-XF-OSs" firstAttribute="centerY" secondItem="yq1-ed-KzG" secondAttribute="centerY" id="KMj-47-7Wy"/>
+                    <constraint firstItem="4ax-XF-OSs" firstAttribute="centerX" secondItem="yq1-ed-KzG" secondAttribute="centerX" id="N3q-Db-po6"/>
+                    <constraint firstItem="4ax-XF-OSs" firstAttribute="top" secondItem="yq1-ed-KzG" secondAttribute="top" constant="10" id="NZi-ul-7hL"/>
+                    <constraint firstItem="4ax-XF-OSs" firstAttribute="leading" secondItem="yq1-ed-KzG" secondAttribute="leading" constant="30" id="ss9-Cx-XHM"/>
                 </constraints>
             </collectionViewCellContentView>
             <userDefinedRuntimeAttributes>

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
@@ -9,74 +9,66 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="y1b-z6-oh3" customClass="WalkExerciseCollectionViewCell" customModule="MomCare" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="365" height="100"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="Id2-0k-a5Z" customClass="WalkExerciseCollectionViewCell" customModule="MomCare" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="360" height="154"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="XdG-gX-wgC">
-                <rect key="frame" x="0.0" y="0.0" width="365" height="100"/>
+            <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="1Ad-Nk-UGy">
+                <rect key="frame" x="0.0" y="0.0" width="360" height="154"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="MH9-ck-Jel">
-                        <rect key="frame" x="20" y="14.666666666666664" width="325" height="70.666666666666686"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="ioK-Nm-HnM">
+                        <rect key="frame" x="31.666666666666657" y="106.66666666666667" width="297" height="37.333333333333329"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ASI-Ac-8rt">
-                                <rect key="frame" x="0.0" y="0.0" width="325" height="20.333333333333332"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="176" translatesAutoresizingMaskIntoConstraints="NO" id="Vo0-rl-yLJ">
+                                <rect key="frame" x="0.0" y="0.0" width="297" height="20.333333333333332"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Walking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4AY-Ia-qMP">
-                                        <rect key="frame" x="0.0" y="0.0" width="63.333333333333336" height="20.333333333333332"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="376 steps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sma-5a-ZgU">
+                                        <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="37.6% completed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J1Q-ns-i0h">
-                                        <rect key="frame" x="73.333333333333329" y="0.0" width="251.66666666666669" height="20.333333333333332"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="i0G-2b-6MN">
-                                <rect key="frame" x="0.0" y="30.333333333333336" width="325" height="18"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="376 Steps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="giz-Qg-uGU">
-                                        <rect key="frame" x="0.0" y="0.0" width="162.66666666666666" height="18"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hRT-nl-lgo">
-                                        <rect key="frame" x="162.66666666666663" y="0.0" width="162.33333333333337" height="18"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wT6-lc-E0f">
+                                        <rect key="frame" x="258.66666666666663" y="0.0" width="38.333333333333314" height="20.333333333333332"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <progressView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="gXw-fw-i8m">
-                                <rect key="frame" x="0.0" y="66.666666666666657" width="325" height="4"/>
-                                <color key="tintColor" red="0.25882352941176467" green="0.25882352941176467" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="RFB-iT-NE6">
+                                <rect key="frame" x="0.0" y="33.333333333333329" width="297" height="4"/>
+                                <color key="tintColor" red="0.25098040700000002" green="0.25098040700000002" blue="0.25098040700000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </progressView>
+                        </subviews>
+                    </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="tfV-Qa-QCx">
+                        <rect key="frame" x="24" y="20" width="186.66666666666666" height="20.333333333333329"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Walking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CAS-Sl-wsx">
+                                <rect key="frame" x="0.0" y="0.0" width="63.333333333333336" height="20.333333333333332"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="37.6% completed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tc7-8R-8Mn">
+                                <rect key="frame" x="81.333333333333343" y="0.0" width="105.33333333333334" height="20.333333333333332"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                     </stackView>
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="MH9-ck-Jel" firstAttribute="leading" secondItem="XdG-gX-wgC" secondAttribute="leading" constant="20" symbolic="YES" id="58O-tq-eqV"/>
-                    <constraint firstItem="gXw-fw-i8m" firstAttribute="width" secondItem="XdG-gX-wgC" secondAttribute="width" multiplier="0.890411" id="Dde-gO-nX5"/>
-                    <constraint firstItem="MH9-ck-Jel" firstAttribute="centerX" secondItem="XdG-gX-wgC" secondAttribute="centerX" id="ePc-lV-Kch"/>
-                    <constraint firstAttribute="trailing" secondItem="MH9-ck-Jel" secondAttribute="trailing" constant="20" symbolic="YES" id="fjr-Rh-jwv"/>
-                    <constraint firstItem="MH9-ck-Jel" firstAttribute="centerY" secondItem="XdG-gX-wgC" secondAttribute="centerY" id="zH8-k9-BfS"/>
+                    <constraint firstItem="tfV-Qa-QCx" firstAttribute="leading" secondItem="1Ad-Nk-UGy" secondAttribute="leading" constant="24" id="b6i-Ag-BVh"/>
+                    <constraint firstItem="ioK-Nm-HnM" firstAttribute="centerX" secondItem="1Ad-Nk-UGy" secondAttribute="centerX" id="ojO-9Y-DEy"/>
+                    <constraint firstAttribute="bottom" secondItem="ioK-Nm-HnM" secondAttribute="bottom" constant="10" id="ssw-AO-6bF"/>
+                    <constraint firstItem="tfV-Qa-QCx" firstAttribute="top" secondItem="1Ad-Nk-UGy" secondAttribute="top" constant="20" id="tSP-5F-kET"/>
                 </constraints>
-                <userDefinedRuntimeAttributes>
-                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                        <integer key="value" value="16"/>
-                    </userDefinedRuntimeAttribute>
-                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.maskstoBounds" value="YES"/>
-                </userDefinedRuntimeAttributes>
             </collectionViewCellContentView>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-            <size key="customSize" width="344" height="112"/>
+            <size key="customSize" width="360" height="154"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                     <integer key="value" value="16"/>
@@ -84,12 +76,12 @@
                 <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
             </userDefinedRuntimeAttributes>
             <connections>
-                <outlet property="completionPercentageLabel" destination="J1Q-ns-i0h" id="7Zg-Tz-l7s"/>
-                <outlet property="progressView" destination="gXw-fw-i8m" id="Nia-q9-uqU"/>
-                <outlet property="stepsGoalLabel" destination="hRT-nl-lgo" id="EHs-fY-BOa"/>
-                <outlet property="stepsLabel" destination="giz-Qg-uGU" id="1sP-TM-PLG"/>
+                <outlet property="completionPercentageLabel" destination="tc7-8R-8Mn" id="osd-Fv-xnF"/>
+                <outlet property="progressView" destination="RFB-iT-NE6" id="3RE-1p-5T3"/>
+                <outlet property="stepsGoalLabel" destination="wT6-lc-E0f" id="Nab-Jx-raI"/>
+                <outlet property="stepsLabel" destination="Sma-5a-ZgU" id="R3l-sW-jVD"/>
             </connections>
-            <point key="canvasLocation" x="537" y="56"/>
+            <point key="canvasLocation" x="514.50381679389307" y="61.267605633802823"/>
         </collectionViewCell>
     </objects>
 </document>

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
@@ -43,7 +43,7 @@
                         </subviews>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="18" translatesAutoresizingMaskIntoConstraints="NO" id="tfV-Qa-QCx">
-                        <rect key="frame" x="24" y="20" width="186.66666666666666" height="20.333333333333329"/>
+                        <rect key="frame" x="20" y="20" width="186.66666666666666" height="20.333333333333329"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Walking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CAS-Sl-wsx">
                                 <rect key="frame" x="0.0" y="0.0" width="63.333333333333336" height="20.333333333333332"/>
@@ -62,7 +62,7 @@
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="tfV-Qa-QCx" firstAttribute="leading" secondItem="1Ad-Nk-UGy" secondAttribute="leading" constant="24" id="b6i-Ag-BVh"/>
+                    <constraint firstItem="tfV-Qa-QCx" firstAttribute="leading" secondItem="1Ad-Nk-UGy" secondAttribute="leading" constant="20" id="b6i-Ag-BVh"/>
                     <constraint firstItem="ioK-Nm-HnM" firstAttribute="centerX" secondItem="1Ad-Nk-UGy" secondAttribute="centerX" id="ojO-9Y-DEy"/>
                     <constraint firstAttribute="bottom" secondItem="ioK-Nm-HnM" secondAttribute="bottom" constant="10" id="ssw-AO-6bF"/>
                     <constraint firstItem="tfV-Qa-QCx" firstAttribute="top" secondItem="1Ad-Nk-UGy" secondAttribute="top" constant="20" id="tSP-5F-kET"/>

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/WalkCellMyPlan.xib
@@ -17,27 +17,27 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="13" translatesAutoresizingMaskIntoConstraints="NO" id="ioK-Nm-HnM">
-                        <rect key="frame" x="31.666666666666657" y="106.66666666666667" width="297" height="37.333333333333329"/>
+                        <rect key="frame" x="20" y="109" width="320" height="35"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" spacing="176" translatesAutoresizingMaskIntoConstraints="NO" id="Vo0-rl-yLJ">
-                                <rect key="frame" x="0.0" y="0.0" width="297" height="20.333333333333332"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="130" translatesAutoresizingMaskIntoConstraints="NO" id="Vo0-rl-yLJ">
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="18"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="376 steps" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sma-5a-ZgU">
-                                        <rect key="frame" x="0.0" y="0.0" width="82.666666666666671" height="20.333333333333332"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="68.333333333333329" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wT6-lc-E0f">
-                                        <rect key="frame" x="258.66666666666663" y="0.0" width="38.333333333333314" height="20.333333333333332"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1000" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wT6-lc-E0f">
+                                        <rect key="frame" x="285.33333333333331" y="0.0" width="34.666666666666686" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="RFB-iT-NE6">
-                                <rect key="frame" x="0.0" y="33.333333333333329" width="297" height="4"/>
+                                <rect key="frame" x="0.0" y="31" width="320" height="4"/>
                                 <color key="tintColor" red="0.25098040700000002" green="0.25098040700000002" blue="0.25098040700000002" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </progressView>
                         </subviews>
@@ -62,6 +62,7 @@
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
+                    <constraint firstItem="ioK-Nm-HnM" firstAttribute="leading" secondItem="1Ad-Nk-UGy" secondAttribute="leading" constant="20" id="TH3-ZV-fkn"/>
                     <constraint firstItem="tfV-Qa-QCx" firstAttribute="leading" secondItem="1Ad-Nk-UGy" secondAttribute="leading" constant="20" id="b6i-Ag-BVh"/>
                     <constraint firstItem="ioK-Nm-HnM" firstAttribute="centerX" secondItem="1Ad-Nk-UGy" secondAttribute="centerX" id="ojO-9Y-DEy"/>
                     <constraint firstAttribute="bottom" secondItem="ioK-Nm-HnM" secondAttribute="bottom" constant="10" id="ssw-AO-6bF"/>


### PR DESCRIPTION
## Summary by Sourcery

Unify and simplify the sizing of exercise collection view cells and update related XIB layouts to fix UI inconsistencies in the MyPlan Exercise tab.

Enhancements:
- Replace per-item hardcoded sizes with a dynamic width calculation and a fixed height of 105 for all exercise cells.
- Update ExerciseCell, ExerciseDateCell, and WalkCellMyPlan XIBs to align with the new cell sizing and layout.