### PR TITLE
Update exercise breathing page and UI color consistency

### DIFF
--- a/MomCare/Common/DataControllers/ContentHandler.swift
+++ b/MomCare/Common/DataControllers/ContentHandler.swift
@@ -238,7 +238,10 @@ extension ContentHandler {
         guard let exercises else {
             return nil
         }
-
+//        let exercises = [
+//            Exercise(name: "breath", type: .breathing, duration: 10, description: "breath", tags: ["h"], level: .beginner, week: "3", assignedAt: Date())
+//        ]fetch
+        
         return exercises
     }
 }

--- a/MomCare/Common/DataControllers/ContentHandler.swift
+++ b/MomCare/Common/DataControllers/ContentHandler.swift
@@ -234,13 +234,13 @@ extension ContentHandler {
 
 extension ContentHandler {
     func fetchExercises() async -> [Exercise]? {
-        let exercises: [Exercise]? = await NetworkManager.shared.get(url: Endpoint.exercises.urlString)
-        guard let exercises else {
-            return nil
-        }
-//        let exercises = [
-//            Exercise(name: "breath", type: .breathing, duration: 10, description: "breath", tags: ["h"], level: .beginner, week: "3", assignedAt: Date())
-//        ]fetch
+//        let exercises: [Exercise]? = await NetworkManager.shared.get(url: Endpoint.exercises.urlString)
+//        guard let exercises else {
+//            return nil
+//        }
+        let exercises = [
+            Exercise(name: "breath", type: .breathing, duration: 10, description: "breath", tags: ["h"], level: .beginner, week: "3", assignedAt: Date())
+        ]
         
         return exercises
     }

--- a/MomCare/Common/EventKitHandler.swift
+++ b/MomCare/Common/EventKitHandler.swift
@@ -126,7 +126,7 @@ actor EventKitHandler {
         let now = Date()
 
         let startDate = Calendar.current.date(byAdding: .month, value: -1, to: now)
-        let endDate = Calendar.current.date(byAdding: .month, value: 1, to: now)
+        let endDate = Calendar.current.date(byAdding: .month, value: 2, to: now)
 
         return fetchAppointments(startDate: startDate, endDate: endDate)
     }
@@ -264,7 +264,7 @@ actor EventKitHandler {
         let now = Date()
 
         let startDate = Calendar.current.date(byAdding: .month, value: -1, to: now)
-        let endDate = Calendar.current.date(byAdding: .month, value: 1, to: now)
+        let endDate = Calendar.current.date(byAdding: .year, value: 5, to: Date())
 
         return fetchReminders(startDate: startDate, endDate: endDate, completionHandler: completionHandler)
     }

--- a/MomCare/Controllers/DashboardControllers/DashboardViewController/DashboardViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/DashboardViewController/DashboardViewController.swift
@@ -133,6 +133,7 @@ class DashboardViewController: UIViewController, UICollectionViewDataSource, UIC
 
 
 
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         if offsetY > 0 {

--- a/MomCare/Controllers/DashboardControllers/DashboardViewController/DashboardViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/DashboardViewController/DashboardViewController.swift
@@ -90,41 +90,48 @@ class DashboardViewController: UIViewController, UICollectionViewDataSource, UIC
     @IBAction func unwinToDashboard(_ segue: UIStoryboardSegue) {}
 
     func setupProfileButton() {
-        if let navigationBar = navigationController?.navigationBar {
-            let customView = UIView()
-            customView.backgroundColor = .clear
+        guard let navigationBar = navigationController?.navigationBar else { return }
 
-            let profileBtn = UIButton()
-            if let profileImage = UIImage(named: "person.crop.circle.fill") {
-                profileBtn.setImage(profileImage, for: .normal)
-            }
+        let customView = UIView()
+        customView.backgroundColor = .clear
 
-            profileBtn.addTarget(self, action: #selector(profileIconTapped), for: .touchUpInside)
+        let profileBtn = UIButton(type: .system)
 
-            profileBtn.tintColor = .gray
-
-            customView.addSubview(profileBtn)
-            navigationBar.addSubview(customView)
-
-            profileBtn.translatesAutoresizingMaskIntoConstraints = false
-            customView.translatesAutoresizingMaskIntoConstraints = false
-
-            NSLayoutConstraint.activate([
-                // Place custom view at the bottom right
-                customView.trailingAnchor.constraint(equalTo: navigationBar.trailingAnchor, constant: -16),
-                customView.bottomAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: -10),
-                customView.widthAnchor.constraint(equalToConstant: 40),
-                customView.heightAnchor.constraint(equalToConstant: 40),
-
-                profileBtn.centerXAnchor.constraint(equalTo: customView.centerXAnchor),
-                profileBtn.centerYAnchor.constraint(equalTo: customView.centerYAnchor),
-                profileBtn.widthAnchor.constraint(equalToConstant: 36),
-                profileBtn.heightAnchor.constraint(equalToConstant: 36)
-            ])
-
-            profileButton = profileBtn
+        // Set symbol config for larger icon
+        let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .regular)
+        if let profileImage = UIImage(systemName: "person.crop.circle.fill", withConfiguration: config)?.withRenderingMode(.alwaysTemplate) {
+            profileBtn.setImage(profileImage, for: .normal)
         }
+
+        profileBtn.tintColor = UIColor(hex: "#924350")
+        profileBtn.addTarget(self, action: #selector(profileIconTapped), for: .touchUpInside)
+
+        profileBtn.imageView?.contentMode = .scaleAspectFit
+        profileBtn.contentHorizontalAlignment = .fill
+        profileBtn.contentVerticalAlignment = .fill
+
+        customView.addSubview(profileBtn)
+        navigationBar.addSubview(customView)
+
+        profileBtn.translatesAutoresizingMaskIntoConstraints = false
+        customView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            customView.trailingAnchor.constraint(equalTo: navigationBar.trailingAnchor, constant: -16),
+            customView.bottomAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: -10),
+            customView.widthAnchor.constraint(equalToConstant: 40),
+            customView.heightAnchor.constraint(equalToConstant: 40),
+
+            profileBtn.centerXAnchor.constraint(equalTo: customView.centerXAnchor),
+            profileBtn.centerYAnchor.constraint(equalTo: customView.centerYAnchor),
+            profileBtn.widthAnchor.constraint(equalToConstant: 36),
+            profileBtn.heightAnchor.constraint(equalToConstant: 36)
+        ])
+
+        profileButton = profileBtn
     }
+
+
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
@@ -18,6 +18,7 @@ class HealthDetailsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.navigationBar.tintColor = UIColor(hex: "924350")
         updatePageElements()
     }
 

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/HealthDetailsTableViewController.swift
@@ -18,7 +18,7 @@ class HealthDetailsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.tintColor = UIColor(hex: "924350")
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
         updatePageElements()
     }
 

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/CodeOfConductTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/CodeOfConductTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  CodeOfConductTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class CodeOfConductTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/CookiePolicyTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/CookiePolicyTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  CookiePolicyTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class CookiePolicyTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/DataUsageTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/DataUsageTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  DataUsageTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class DataUsageTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/GlobalRightsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/GlobalRightsTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  GlobalRightsTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class GlobalRightsTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/PrivacyPolicyTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/PrivacyPolicyTableViewController.swift
@@ -1,0 +1,48 @@
+//
+//  LegalComplianceTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class PrivacyPolicyTableViewController: UITableViewController {
+
+    
+    @IBOutlet weak var privacyPoliceDescription: UILabel!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let bullet = "\u{2022}"
+        let items = [
+                "What data we collect",
+                "Why we collect it",
+                "How it’s used, stored, and shared",
+                "Your rights over your data"
+            ]
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.headIndent = 15           // space after bullet
+        paragraphStyle.paragraphSpacing = 6      // space between bullet lines
+        paragraphStyle.lineSpacing = 4           // line spacing
+        paragraphStyle.alignment = .left
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .paragraphStyle: paragraphStyle,
+            .font: UIFont.systemFont(ofSize: 16),
+            .foregroundColor: UIColor.label
+        ]
+
+        let bulletText = NSMutableAttributedString()
+
+        for item in items {
+            let line = "\(bullet) \(item)\n"
+            let attributedLine = NSAttributedString(string: line, attributes: attributes)
+            bulletText.append(attributedLine)
+        }
+
+        privacyPoliceDescription.numberOfLines = 0
+        privacyPoliceDescription.attributedText = bulletText
+    }
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/PrivacyPolicyTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/PrivacyPolicyTableViewController.swift
@@ -35,10 +35,10 @@ class PrivacyPolicyTableViewController: UITableViewController {
 
         let bulletText = NSMutableAttributedString()
 
-        for item in items {
-            let line = "\(bullet) \(item)\n"
-            let attributedLine = NSAttributedString(string: line, attributes: attributes)
-            bulletText.append(attributedLine)
+        for (index, item) in items.enumerated() {
+            let suffix = index == items.count - 1 ? "" : "\n"
+            let line = "\(bullet) \(item)\(suffix)"
+            bulletText.append(NSAttributedString(string: line, attributes: attributes))
         }
 
         privacyPoliceDescription.numberOfLines = 0

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/TermsOfServiceTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalAndCompliance/TermsOfServiceTableViewController.swift
@@ -1,0 +1,89 @@
+//
+//  TermsOfServiceTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class TermsOfServiceTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Uncomment the following line to preserve selection between presentations
+        // self.clearsSelectionOnViewWillAppear = false
+
+        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
+        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        // #warning Incomplete implementation, return the number of sections
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        // #warning Incomplete implementation, return the number of rows
+        return 0
+    }
+
+    /*
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "reuseIdentifier", for: indexPath)
+
+        // Configure the cell...
+
+        return cell
+    }
+    */
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalComplianceTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/LegalComplianceTableViewController.swift
@@ -1,0 +1,17 @@
+//
+//  LegalComplianceTableViewController.swift
+//  MomCare
+//
+//  Created by Nupur on 23/07/25.
+//
+
+import UIKit
+
+class LegalComplianceTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+
+}

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/PersonalDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/PersonalDetailsTableViewController.swift
@@ -31,6 +31,8 @@ class PersonalDetailsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.navigationBar.tintColor = UIColor(hex: "924350")
+
         updateElements()
         setupPickers()
 

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/PersonalDetailsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/PersonalDetailsTableViewController.swift
@@ -31,7 +31,7 @@ class PersonalDetailsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationController?.navigationBar.tintColor = UIColor(hex: "924350")
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
 
         updateElements()
         setupPickers()

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/ProfileSecurityTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/ProfileSecurityTableViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SettingsTableViewController: UITableViewController {
+class ProfileSecurityTableViewController: UITableViewController {
 
     @IBOutlet var emailLabel: UILabel!
     @IBOutlet var phoneNumberLabel: UILabel!

--- a/MomCare/Controllers/DashboardControllers/ProfileViewControllers/SettingsTableViewController.swift
+++ b/MomCare/Controllers/DashboardControllers/ProfileViewControllers/SettingsTableViewController.swift
@@ -21,6 +21,7 @@ class SettingsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         updatePageElements()
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/MomCare/Controllers/LoginPageControllers/LoginTableViewController.swift
+++ b/MomCare/Controllers/LoginPageControllers/LoginTableViewController.swift
@@ -15,6 +15,7 @@ class LoginTableViewController: UITableViewController, UITextFieldDelegate {
         passwordField.delegate = self
 
         emailAddressField.becomeFirstResponder()
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
     }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/MomCare/Controllers/MoodnestControllers/MoodNestViewController.swift
+++ b/MomCare/Controllers/MoodnestControllers/MoodNestViewController.swift
@@ -21,7 +21,7 @@ class MoodNestViewController: UIViewController, UICollectionViewDataSource, UICo
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
         outerView.layer.cornerRadius = 30
         registerAllNibs()
 

--- a/MomCare/Controllers/MoodnestControllers/MoodnestViewController.swift
+++ b/MomCare/Controllers/MoodnestControllers/MoodnestViewController.swift
@@ -21,7 +21,7 @@ class MoodNestViewController: UIViewController, UICollectionViewDataSource, UICo
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
         outerView.layer.cornerRadius = 30
         registerAllNibs()
 

--- a/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
@@ -249,7 +249,7 @@ class BreathingPlayerViewController: UIViewController {
             }
         }
     }
-
+    
     private func updateCurrentCount() {
         if currentCount >= 1 {
             timerLabel.text = "\(currentCount)"
@@ -586,6 +586,12 @@ class BreathingPlayerViewController: UIViewController {
         }
         
         startPauseButton.setTitle("Start", for: .normal)
+        
+        // Reset the stop button to its original state and action
+        stopButton.setTitle("Stop", for: .normal)
+        stopButton.removeTarget(self, action: #selector(doneButtonTapped), for: .touchUpInside)
+        stopButton.addTarget(self, action: #selector(stopButtonTapped), for: .touchUpInside)
+        
         UIView.animate(withDuration: 0.3) {
             self.stopButton.isHidden = true
             self.assuringMessageLabel.alpha = 0
@@ -617,10 +623,18 @@ class BreathingPlayerViewController: UIViewController {
             exerciseTimer?.invalidate()
             playerState = .finished
             animateFlowerBloomAndShowMessage()
+            
+            // Configure buttons for the finished state
+            startPauseButton.setTitle("Restart", for: .normal)
+            
+            // Repurpose the stop button to act as a "Done" button
+            stopButton.setTitle("Done", for: .normal)
+            stopButton.removeTarget(self, action: #selector(stopButtonTapped), for: .touchUpInside)
+            stopButton.addTarget(self, action: #selector(doneButtonTapped), for: .touchUpInside)
+            
             UIView.animate(withDuration: 0.5) {
                 self.startPauseButton.alpha = 1 // Show it again
-                self.startPauseButton.setTitle("Restart", for: .normal)
-                self.stopButton.isHidden = true
+                self.stopButton.isHidden = false // Ensure it's visible
             }
             return
         }
@@ -630,6 +644,15 @@ class BreathingPlayerViewController: UIViewController {
         remainingMinSec = Double(remainingMinutes) * 60 + Double(remainingSecondsPart)
         
         totalBreatingDuration.text = String(format: "%02d:%02d", remainingMinutes, remainingSecondsPart)
+    }
+    
+    @objc private func doneButtonTapped() {
+        // Dismiss or pop to previous screen
+        if let nav = self.navigationController {
+            nav.popViewController(animated: true)
+        } else {
+            self.dismiss(animated: true)
+        }
     }
     
 }

--- a/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
@@ -14,14 +14,22 @@ class BreathingPlayerViewController: UIViewController {
     @IBOutlet var overallTimerLabel: UILabel!
 
     var duration: Int = 10
+    let petalColors: [UIColor] = [
+        UIColor(hex: "#C27086", alpha: 0.5),
+        UIColor(hex: "#C98195", alpha: 0.5),
+        UIColor(hex: "#D092A3", alpha: 0.5),
+        UIColor(hex: "#D9A6B4", alpha: 0.5),
+        UIColor(hex: "#DDB7C2", alpha: 0.5),
+    ]
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         overallTimerLabel.text = formatTimerLabel(duration)
         instructionLabel.text = "Ready"
+        view.backgroundColor = UIColor(hex: "#B04E6F")
 
-        createInitialFlower()
+        createInitialFlower(colors: petalColors)
     }
 
     @IBAction func startPauseButtonTapped(_ sender: UIButton) {
@@ -159,16 +167,17 @@ extension BreathingPlayerViewController {
         return shapeLayer
     }
 
-    func createInitialFlower() {
-        let numberOfCircles = 6
+    func createInitialFlower(colors: [UIColor]) {
+        let numberOfCircles = colors.count
         let radius: CGFloat = view.bounds.width / 6
 
-        for _ in 0..<numberOfCircles {
-            let layer = drawCenteredFilledCircle(in: animationView, radius: radius, fillColor: UIColor.systemRed.withAlphaComponent(0.5))
-
+        for i in 0..<numberOfCircles {
+            let fillColor = colors[i]
+            let layer = drawCenteredFilledCircle(in: animationView, radius: radius, fillColor: fillColor)
             circles.append(layer)
         }
     }
+
 
     func animateOpenFlowerPetal(shapeLayer: CAShapeLayer, angle: CGFloat) {
         let animation = CABasicAnimation(keyPath: "position")

--- a/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/BreathingPlayerViewController.swift
@@ -1,225 +1,635 @@
 import UIKit
 
 class BreathingPlayerViewController: UIViewController {
-
+    
     // MARK: Internal
-
-    @IBOutlet var instructionLabel: UILabel!
-    @IBOutlet var instructionTimerLabel: UILabel!
-
-    @IBOutlet var animationView: UIView!
-    @IBOutlet var startPauseButton: UIButton!
-    @IBOutlet var stopButton: UIButton!
-
-    @IBOutlet var overallTimerLabel: UILabel!
-
-    var duration: Int = 10
-    let petalColors: [UIColor] = [
-        UIColor(hex: "#C27086", alpha: 0.5),
-        UIColor(hex: "#C98195", alpha: 0.5),
-        UIColor(hex: "#D092A3", alpha: 0.5),
-        UIColor(hex: "#D9A6B4", alpha: 0.5),
-        UIColor(hex: "#DDB7C2", alpha: 0.5),
-    ]
-
+    
+    @IBOutlet var totalBreatingDuration: UILabel!
+    
+    var remainingMinSec: Double = 0.0
+    var completedPercentage: Double = 0.0
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        overallTimerLabel.text = formatTimerLabel(duration)
-        instructionLabel.text = "Ready"
-        view.backgroundColor = UIColor(hex: "#B04E6F")
-
-        createInitialFlower(colors: petalColors)
+        setupAnimatedGradientBackground()
+        setupCircleLayers()
+        setupInstructionLabel()
+        setupTimerLabel()
+        setupAssuringMessageLabel()
+        setupControlButtons()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+    }
+    
+    func updateGradientBackground() {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        
+        let upperColor = UIColor(hex: "#1e0d31")
+        let middleColor = UIColor(hex: "#13102f")
+        let bottomColor = UIColor(hex: "#0f102e")
+        
+        gradientLayer.colors = [
+            upperColor.withAlphaComponent(1.0).cgColor,
+            middleColor.withAlphaComponent(1.0).cgColor,
+            bottomColor.withAlphaComponent(1.0).cgColor
+        ]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        
+        view.layer.insertSublayer(gradientLayer, at: 0)
+    }
+    
+    func exrciseDurationSetup() async {
+        var i = 0
+        
+        while 5 * 60 - i > 0 {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            DispatchQueue.main.async {
+                i += 1
+                let remainingSeconds = 5 * 60 - i
+                
+                let remainingMinutes = remainingSeconds / 60
+                let remainingSecondsPart = remainingSeconds % 60
+                self.remainingMinSec = Double(remainingMinutes) * 60 + Double(remainingSecondsPart)
+                
+                self.totalBreatingDuration.text = String(format: "%02d:%02d", remainingMinutes, remainingSecondsPart)
+            }
+        }
+    }
+    
+    @IBAction func breathingStopButtonTapped(_ sender: UIButton) {
+        let remainingTime: Double = remainingMinSec
+        let completedTime: Double = totalBreathingTime - remainingTime
+        completedPercentage = (completedTime / totalBreathingTime * 100)
+    }
+    
+    // MARK: - Animated Gradient Background
+    private var animatedGradientLayer: CAGradientLayer?
+    private var gradientAnimation: CABasicAnimation?
+    
+    private func setupAnimatedGradientBackground() {
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = view.bounds
+        // Soft, calming theme colors (purple, blue, pink)
+        let color1 = UIColor(hex: "#1e0d31")
+        let color2 = UIColor(hex: "#3a2766")
+        let color3 = UIColor(hex: "#6e4fa3")
+        let color4 = UIColor(hex: "#bfaee0")
+        let color5 = UIColor(hex: "#f7d6e0")
+        gradientLayer.colors = [
+            color1.cgColor,
+            color2.cgColor,
+            color3.cgColor,
+            color4.cgColor,
+            color5.cgColor
+        ]
+        gradientLayer.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradientLayer.endPoint = CGPoint(x: 0.5, y: 1.0)
+        view.layer.insertSublayer(gradientLayer, at: 0)
+        animatedGradientLayer = gradientLayer
+        animateGradientColors()
+    }
+    
+    private func animateGradientColors() {
+        guard let gradientLayer = animatedGradientLayer else { return }
+        let fromColors = gradientLayer.colors
+        let toColors: [CGColor] = [
+            UIColor(hex: "#2a1a4d").cgColor,
+            UIColor(hex: "#4b3577").cgColor,
+            UIColor(hex: "#8c6fc9").cgColor,
+            UIColor(hex: "#e3c6f7").cgColor,
+            UIColor(hex: "#f7d6e0").cgColor
+        ]
+        let animation = CABasicAnimation(keyPath: "colors")
+        animation.fromValue = fromColors
+        animation.toValue = toColors
+        animation.duration = 6.0
+        animation.autoreverses = true
+        animation.repeatCount = .infinity
+        animation.isRemovedOnCompletion = false
+        gradientLayer.add(animation, forKey: "colorChange")
+    }
+    
+    // MARK: - Assuring Message
+    private let assuringMessageLabel: UILabel = .init()
+    private func setupAssuringMessageLabel() {
+        assuringMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(assuringMessageLabel)
+        NSLayoutConstraint.activate([
+            assuringMessageLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            assuringMessageLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 120)
+        ])
+        assuringMessageLabel.textColor = UIColor(hex: "#f7d6e0")
+        assuringMessageLabel.font = .systemFont(ofSize: 30, weight: .bold)
+        assuringMessageLabel.textAlignment = .center
+        assuringMessageLabel.numberOfLines = 0
+        assuringMessageLabel.alpha = 0
+        assuringMessageLabel.layer.shadowColor = UIColor.black.cgColor
+        assuringMessageLabel.layer.shadowOpacity = 0.2
+        assuringMessageLabel.layer.shadowRadius = 8
+        assuringMessageLabel.layer.shadowOffset = CGSize(width: 0, height: 2)
+        assuringMessageLabel.text = "You did amazing!\nTake this calm with you."
+    }
+    private func showAssuringMessage() {
+        UIView.animate(withDuration: 1.2, delay: 0.2, options: [.curveEaseInOut]) {
+            self.assuringMessageLabel.alpha = 1
+        }
+    }
+    
+    // MARK: Private
+    
+    private var circlesContainer: CALayer = .init()
+    private var circleLayers: [CAShapeLayer] = []
+    private var isInhaling = true
+    private let instructionLabel: UILabel = .init()
+    private let timerLabel: UILabel = .init() // New timer label
+    private var timer: Timer? // Timer for updating countdown
+    private var currentCount = 0
+    private var breathingCycles = 0
+    
+    // MARK: - State & Controls
+    private enum PlayerState { case ready, playing, paused, finished }
+    private var playerState: PlayerState = .ready
+    private var startPauseButton: UIButton!
+    private var stopButton: UIButton!
+    private var exerciseTimer: Timer?
+    private var secondsElapsed = 0
+    
+    // pause
+    private var nextStateWorkItem: DispatchWorkItem?
+    private var animationPhaseStartTime: TimeInterval = 0
+    private var timeRemainingForPhase: TimeInterval = 0
+    
+    
+    // Configuration
+    private let numberOfPetals = 6
+    private let circleSize: CGFloat = 100
+    private let animationDuration: TimeInterval = 4.0
+    private let spreadDistance: CGFloat = 60
+    private let textAnimationDuration: TimeInterval = 0.5
+    private let totalBreathingTime: Double = 10
+    private let petalColors: [UIColor] = [
+        UIColor(hex: "#bfaee0"), // soft purple
+        UIColor(hex: "#f7d6e0"), // soft pink
+        UIColor(hex: "#a3d8f4"), // soft blue
+        UIColor(hex: "#c2e9e0"), // soft mint
+        UIColor(hex: "#f9e7b4"), // soft yellow
+        UIColor(hex: "#e3c6f7")  // lavender
+    ]
+    private let centerColor = UIColor(hex: "#fff6f0") // warm cream
+    
+    private func setupInstructionLabel() {
+        instructionLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(instructionLabel)
+        NSLayoutConstraint.activate([
+            instructionLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            instructionLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120)
+        ])
+        instructionLabel.textColor = UIColor(hex: "#fff6f0")
+        instructionLabel.font = .systemFont(ofSize: 36, weight: .semibold)
+        instructionLabel.text = "Inhale"
+        instructionLabel.alpha = 1
+        instructionLabel.layer.shadowColor = UIColor.black.cgColor
+        instructionLabel.layer.shadowOpacity = 0.18
+        instructionLabel.layer.shadowRadius = 6
+        instructionLabel.layer.shadowOffset = CGSize(width: 0, height: 2)
+    }
+    
+    
+    
+    private func animateInstructionChange(to newText: String) {
+        UIView.animate(withDuration: textAnimationDuration, delay: 0, options: .curveLinear) {
+            self.instructionLabel.transform = CGAffineTransform(translationX: 0, y: 0)
+            self.instructionLabel.alpha = 0
+        }
+        
+        // Animate new text up and fade in
+        UIView.animate(withDuration: textAnimationDuration, delay: 0, options: .curveLinear) {
+        } completion: { _ in
+            // Reset for next transition
+            self.instructionLabel.text = newText
+            self.instructionLabel.transform = .identity
+            self.instructionLabel.alpha = 1
+        }
+    }
+    
+    private func setupTimerLabel() {
+        timerLabel.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(timerLabel)
+        NSLayoutConstraint.activate([
+            timerLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            timerLabel.topAnchor.constraint(equalTo: instructionLabel.bottomAnchor, constant: 20)
+        ])
+        timerLabel.textColor = UIColor(hex: "#bfaee0")
+        timerLabel.font = .systemFont(ofSize: 34, weight: .medium)
+        timerLabel.text = ""
+        timerLabel.isHidden = true
+        timerLabel.layer.shadowColor = UIColor.black.cgColor
+        timerLabel.layer.shadowOpacity = 0.15
+        timerLabel.layer.shadowRadius = 5
+        timerLabel.layer.shadowOffset = CGSize(width: 0, height: 2)
+    }
+    
+    private func startTimer(from initialCount: Int = 4) {
+        // Reset and invalidate existing timer if any
+        timer?.invalidate()
+        currentCount = initialCount
+        
+        timerLabel.isHidden = false
+        updateCurrentCount() // Show the first number immediately
+        
+        // Start new timer
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            Task { @MainActor in
+                self.updateCurrentCount()
+            }
+        }
     }
 
-    @IBAction func startPauseButtonTapped(_ sender: UIButton) {
-        if isPaused {
-            startBreathing()
+    private func updateCurrentCount() {
+        if currentCount >= 1 {
+            timerLabel.text = "\(currentCount)"
+        }
+        // Always decrement, but only update label if >= 1
+        currentCount -= 1
+    }
+    
+    private func setupCircleLayers() {
+        // Remove old layers if any
+        circlesContainer.removeFromSuperlayer()
+        circleLayers.removeAll()
+        // Setup container
+        let containerSize = circleSize + (spreadDistance * 2)
+        circlesContainer = CALayer()
+        circlesContainer.frame = CGRect(x: 0, y: 0, width: containerSize, height: containerSize)
+        circlesContainer.position = view.center
+        view.layer.addSublayer(circlesContainer)
+        // Create all circles (center + petals)
+        for i in 0...numberOfPetals {
+            let circle = createCircleLayer(index: i)
+            // All circles start at center
+            circle.position = CGPoint(x: circlesContainer.bounds.midX, y: circlesContainer.bounds.midY)
+            circlesContainer.addSublayer(circle)
+            circleLayers.append(circle)
+        }
+    }
+    
+    private func hideTimer() {
+        timer?.invalidate()
+        timer = nil
+        timerLabel.isHidden = true
+        timerLabel.text = ""
+    }
+    
+    private func createCircleLayer(index: Int) -> CAShapeLayer {
+        let layer = CAShapeLayer()
+        layer.frame = CGRect(x: -circleSize/2, y: -circleSize/2, width: circleSize, height: circleSize)
+        let circlePath = UIBezierPath(
+            arcCenter: CGPoint(x: circleSize/2, y: circleSize/2),
+            radius: circleSize/2,
+            startAngle: 0,
+            endAngle: 2 * .pi,
+            clockwise: true
+        )
+        layer.path = circlePath.cgPath
+        layer.shadowPath = circlePath.cgPath // Fix for square shadow
+        
+        if index == 0 {
+            layer.fillColor = centerColor.withAlphaComponent(0.85).cgColor
         } else {
-            pauseBreathing()
+            let color = petalColors[(index-1) % petalColors.count]
+            layer.fillColor = color.withAlphaComponent(0.7).cgColor
+            layer.shadowColor = color.withAlphaComponent(0.7).cgColor
+            layer.shadowOpacity = 0.5
+            layer.shadowRadius = 16
+            layer.shadowOffset = CGSize(width: 0, height: 0)
         }
-        isPaused.toggle()
+        return layer
     }
-
-    @IBAction func stopButtonTapped(_ sender: UIButton) {
-        pauseBreathing()
-        isPaused = true
-
-        let cancelAction = AlertActionHandler(title: "Cancel", style: .cancel, handler: nil)
-        var confirmAction = AlertActionHandler(title: "Confirm", style: .destructive) { _ in
-            self.dismiss(animated: true)
+    
+    private func startBreathingAnimation() {
+        animateBreathCycle()
+    }
+    
+    private func animateBreathCycle() {
+        if playerState != .playing { return }
+        
+        if isInhaling {
+            animateInstructionChange(to: "Inhale")
+            hideTimer()
+            animateFlowerFormation {
+                if self.playerState != .playing { return }
+                self.animateInstructionChange(to: "Hold")
+                self.startTimer()
+                self.scheduleNextState(after: self.animationDuration)
+            }
+        } else {
+            currentCount = 4
+            animateInstructionChange(to: "Exhale")
+            hideTimer()
+            animateFlowerCollapse {
+                if self.playerState != .playing { return }
+                self.breathingCycles += 1
+                self.isInhaling = true
+                
+                // No delay here, just loop back
+                self.animateBreathCycle()
+            }
         }
-        let alert = Utils.getAlert(title: "Stop Session", message: "Do you want to stop the breathing session?", actions: [cancelAction, confirmAction])
-
-        if duration <= 0 {
-            alert.message = "The session is already completed. Do you want to dismiss?"
-            confirmAction.handler = { _ in
+    }
+    
+    private func scheduleNextState(after delay: TimeInterval) {
+        animationPhaseStartTime = CACurrentMediaTime()
+        nextStateWorkItem = DispatchWorkItem { [weak self] in
+            guard let self = self, self.playerState == .playing else { return }
+            
+            self.isInhaling = false
+            self.animateBreathCycle()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: nextStateWorkItem!)
+    }
+    
+    private func animateFlowerFormation(completion: @escaping () -> Void) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock {
+            // Add a gentle pulse to petals
+            self.pulsePetals()
+            completion()
+        }
+        for (index, circle) in circleLayers.enumerated() {
+            if index == 0 { continue }
+            let angle = (2.0 * .pi * CGFloat(index - 1)) / CGFloat(numberOfPetals)
+            let destinationX = circlesContainer.bounds.midX + cos(angle) * spreadDistance
+            let destinationY = circlesContainer.bounds.midY + sin(angle) * spreadDistance
+            let animation = CABasicAnimation(keyPath: "position")
+            animation.fromValue = CGPoint(x: circlesContainer.bounds.midX, y: circlesContainer.bounds.midY)
+            animation.toValue = CGPoint(x: destinationX, y: destinationY)
+            animation.duration = animationDuration
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            animation.fillMode = .forwards
+            animation.isRemovedOnCompletion = false
+            circle.add(animation, forKey: "position")
+        }
+        CATransaction.commit()
+    }
+    private func pulsePetals() {
+        for (index, circle) in circleLayers.enumerated() {
+            if index == 0 { continue }
+            let pulse = CABasicAnimation(keyPath: "transform.scale")
+            pulse.fromValue = 1.0
+            pulse.toValue = 1.08
+            pulse.duration = 0.7
+            pulse.autoreverses = true
+            pulse.repeatCount = 2
+            pulse.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            circle.add(pulse, forKey: "pulse")
+        }
+    }
+    private func animateFlowerBloomAndShowMessage() {
+        // Animate petals to bloom (scale up and fade in)
+        for (index, circle) in circleLayers.enumerated() {
+            if index == 0 { continue }
+            let bloom = CABasicAnimation(keyPath: "transform.scale")
+            bloom.fromValue = 1.0
+            bloom.toValue = 1.25
+            bloom.duration = 1.2
+            bloom.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            bloom.fillMode = .forwards
+            bloom.isRemovedOnCompletion = false
+            circle.add(bloom, forKey: "bloom")
+        }
+        // Fade in the assuring message after bloom
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.1) {
+            self.showAssuringMessage()
+        }
+    }
+    
+    private func animateFlowerCollapse(completion: @escaping () -> Void) {
+        CATransaction.begin()
+        CATransaction.setCompletionBlock(completion)
+        
+        for (index, circle) in circleLayers.enumerated() {
+            if index == 0 {
+                continue
+            }
+            
+            let animation = CABasicAnimation(keyPath: "position")
+            animation.fromValue = circle.presentation()?.position ?? circle.position
+            animation.toValue = CGPoint(x: circlesContainer.bounds.midX, y: circlesContainer.bounds.midY)
+            animation.duration = animationDuration
+            animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            animation.fillMode = .forwards
+            animation.isRemovedOnCompletion = false
+            
+            circle.add(animation, forKey: "position")
+        }
+        
+        CATransaction.commit()
+    }
+    
+    private func setupControlButtons() {
+        startPauseButton = UIButton(type: .system)
+        startPauseButton.setTitle("Start", for: .normal)
+        startPauseButton.titleLabel?.font = .systemFont(ofSize: 22, weight: .bold)
+        startPauseButton.setTitleColor(UIColor(hex: "#1e0d31"), for: .normal)
+        startPauseButton.backgroundColor = UIColor.white.withAlphaComponent(0.8)
+        startPauseButton.layer.cornerRadius = 30
+        startPauseButton.addTarget(self, action: #selector(startPauseButtonTapped), for: .touchUpInside)
+        startPauseButton.translatesAutoresizingMaskIntoConstraints = false
+        
+        stopButton = UIButton(type: .system)
+        stopButton.setTitle("Stop", for: .normal)
+        stopButton.titleLabel?.font = .systemFont(ofSize: 22, weight: .bold)
+        stopButton.setTitleColor(UIColor.white, for: .normal)
+        stopButton.backgroundColor = UIColor.black.withAlphaComponent(0.25)
+        stopButton.layer.cornerRadius = 30
+        stopButton.addTarget(self, action: #selector(stopButtonTapped), for: .touchUpInside)
+        stopButton.translatesAutoresizingMaskIntoConstraints = false
+        stopButton.isHidden = true // Use isHidden for stack view
+        
+        let stackView = UIStackView(arrangedSubviews: [stopButton, startPauseButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = 20
+        stackView.distribution = .fillEqually
+        
+        view.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -50),
+            stackView.widthAnchor.constraint(equalToConstant: 300),
+            stackView.heightAnchor.constraint(equalToConstant: 60)
+        ])
+    }
+    
+    @objc private func startPauseButtonTapped() {
+        switch playerState {
+        case .ready:
+            // Start
+            playerState = .playing
+            startExercise()
+            startPauseButton.setTitle("Pause", for: .normal)
+            UIView.animate(withDuration: 0.3) {
+                self.stopButton.isHidden = false
+            }
+            
+        case .playing:
+            // Pause
+            playerState = .paused
+            pauseExercise()
+            startPauseButton.setTitle("Resume", for: .normal)
+            
+        case .paused:
+            // Resume
+            playerState = .playing
+            resumeExercise()
+            startPauseButton.setTitle("Pause", for: .normal)
+            
+        case .finished:
+            // Reset to beginning
+            resetExercise()
+        }
+    }
+    
+    @objc private func stopButtonTapped() {
+        pauseExercise() // Pause everything first
+        
+        let alert = UIAlertController(title: "Stop Exercise", message: "Are you sure you want to stop the breathing exercise?", preferredStyle: .alert)
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: { _ in
+            // If they cancel, resume the exercise
+            self.resumeExercise()
+        }))
+        
+        alert.addAction(UIAlertAction(title: "Stop", style: .destructive, handler: { _ in
+            self.playerState = .finished
+            self.resetExercise()
+            // Dismiss or pop to previous screen
+            if let nav = self.navigationController {
+                nav.popViewController(animated: true)
+            } else {
                 self.dismiss(animated: true)
             }
-        } else {
-            alert.message = "Do you want to stop the breathing session?"
-        }
+        }))
+        
         present(alert, animated: true)
     }
-
-    // MARK: Private
-
-    private var isPaused = true
-    private var instructions: [String] = ["Inhale", "Hold", "Exhale"]
-    private var holdDuration: Int = 4
-
-    private var circles: [CAShapeLayer] = []
-
-    private var runnerTask: Task<Void, Never>?
-
-    private var phaseIndex: Int = 0
-    private var phaseRemaining: Int = 4
-
-    private func formatTimerLabel(_ time: Int) -> String {
-        let minutes = Int(time) / 60
-        let seconds = Int(time) % 60
-        return String(format: "%02d:%02d", minutes, seconds)
+    
+    private func startExercise() {
+        // Reset counters and start timers/animations
+        secondsElapsed = 0
+        updateMainTimer() // Show 05:00 immediately
+        startMainTimer()
+        startBreathingAnimation()
     }
-
-    private func startBreathing() {
-        startPauseButton.setTitle("Pause", for: .normal)
-        runnerTask = Task { await runner() }
+    
+    private func pauseExercise() {
+        if playerState != .paused { return }
+        
+        // 1. Pause timers
+        exerciseTimer?.invalidate()
+        timer?.invalidate()
+        
+        // 2. Pause CoreAnimation smoothly
+        let pausedTime = circlesContainer.convertTime(CACurrentMediaTime(), from: nil)
+        circlesContainer.speed = 0
+        circlesContainer.timeOffset = pausedTime
+        
+        // 3. Cancel next state change and calculate remaining time
+        nextStateWorkItem?.cancel()
+        let timeElapsed = CACurrentMediaTime() - animationPhaseStartTime
+        timeRemainingForPhase = animationDuration - timeElapsed
+        if timeRemainingForPhase < 0 { timeRemainingForPhase = 0 }
     }
-
-    private func pauseBreathing() {
+    
+    private func resumeExercise() {
+        if playerState != .playing { return }
+        
+        // 1. Resume main timer
+        startMainTimer()
+        
+        // 2. Resume CoreAnimation smoothly
+        let pausedTime = circlesContainer.timeOffset
+        circlesContainer.speed = 1
+        circlesContainer.timeOffset = 0
+        circlesContainer.beginTime = 0
+        let timeSincePause = circlesContainer.convertTime(CACurrentMediaTime(), from: nil) - pausedTime
+        circlesContainer.beginTime = timeSincePause
+        
+        // 3. Resume countdown timer (if it was running)
+        if !timerLabel.isHidden {
+            startTimer(from: currentCount)
+        }
+        
+        // 4. Reschedule the next state change
+        if isInhaling { // Only reschedule if we were in a waiting phase (Hold)
+            scheduleNextState(after: timeRemainingForPhase)
+        }
+    }
+    
+    private func resetExercise() {
+        exerciseTimer?.invalidate()
+        secondsElapsed = 0
+        breathingCycles = 0
+        isInhaling = true
+        
+        // Reset UI
+        circlesContainer.removeAllAnimations()
+        for circle in circleLayers {
+            circle.removeAllAnimations()
+            circle.position = CGPoint(x: circlesContainer.bounds.midX, y: circlesContainer.bounds.midY)
+        }
+        
         startPauseButton.setTitle("Start", for: .normal)
-        runnerTask?.cancel()
-    }
-
-    private func runner() async {
-        while duration >= 0 && !Task.isCancelled && !isPaused {
-            let currentInstruction = instructions[phaseIndex % instructions.count]
-
-            await MainActor.run {
-                updateUI(for: currentInstruction)
-                triggerAnimationIfNeeded(for: currentInstruction)
-            }
-
-            try? await Task.sleep(nanoseconds: UInt64(1_000_000_000))
-            duration -= 1
-            phaseRemaining -= 1
-
-            if phaseRemaining == 0 {
-                phaseIndex += 1
-                phaseRemaining = holdDuration
-            }
+        UIView.animate(withDuration: 0.3) {
+            self.stopButton.isHidden = true
+            self.assuringMessageLabel.alpha = 0
+            self.startPauseButton.alpha = 1
         }
-
-        await MainActor.run {
-            if duration <= 0 {
-                showCompletion()
-            } else {
-                updateUI(for: instructions[phaseIndex % instructions.count])
+        
+        instructionLabel.text = "Inhale"
+        totalBreatingDuration.text = String(format: "%02d:%02d", 5, 0)
+        
+        playerState = .ready
+    }
+    
+    private func startMainTimer() {
+        exerciseTimer?.invalidate()
+        exerciseTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            Task { @MainActor in
+                self.updateMainTimer()
             }
         }
     }
-
-    @MainActor
-    private func updateUI(for instruction: String) {
-        instructionLabel.text = instruction
-        overallTimerLabel.text = formatTimerLabel(duration)
-
-        if instruction == "Hold" {
-            instructionTimerLabel.text = "\(phaseRemaining)"
-        } else {
-            instructionTimerLabel.text = "--"
-        }
-    }
-
-    @MainActor
-    private func triggerAnimationIfNeeded(for instruction: String) {
-        if phaseRemaining == holdDuration {
-            if instruction == "Inhale" {
-                openAllFlowerPetals()
-            } else if instruction == "Exhale" {
-                closeAllFlowerPetals()
+    
+    private func updateMainTimer() {
+        secondsElapsed += 1
+        let remainingSeconds = Int(totalBreathingTime) - secondsElapsed
+        
+        if remainingSeconds <= 0 {
+            totalBreatingDuration.text = "00:00"
+            exerciseTimer?.invalidate()
+            playerState = .finished
+            animateFlowerBloomAndShowMessage()
+            UIView.animate(withDuration: 0.5) {
+                self.startPauseButton.alpha = 1 // Show it again
+                self.startPauseButton.setTitle("Restart", for: .normal)
+                self.stopButton.isHidden = true
             }
+            return
         }
+        
+        let remainingMinutes = remainingSeconds / 60
+        let remainingSecondsPart = remainingSeconds % 60
+        remainingMinSec = Double(remainingMinutes) * 60 + Double(remainingSecondsPart)
+        
+        totalBreatingDuration.text = String(format: "%02d:%02d", remainingMinutes, remainingSecondsPart)
     }
-
-    @MainActor
-    private func showCompletion() {
-        instructionLabel.text = "Completed 🎉"
-        instructionTimerLabel.text = "--"
-        overallTimerLabel.text = "00:00"
-        startPauseButton.setTitle("Start", for: .normal)
-    }
-
-}
-
-extension BreathingPlayerViewController {
-    func drawCenteredFilledCircle(in view: UIView, radius: CGFloat, fillColor: UIColor) -> CAShapeLayer {
-        let center = CGPoint(x: view.bounds.midX, y: view.bounds.midY)
-        let circlePath = UIBezierPath(arcCenter: center, radius: radius, startAngle: 0, endAngle: CGFloat.pi * 2, clockwise: true)
-
-        let shapeLayer = CAShapeLayer()
-        shapeLayer.path = circlePath.cgPath
-        shapeLayer.fillColor = fillColor.cgColor
-        shapeLayer.strokeColor = nil
-
-        view.layer.addSublayer(shapeLayer)
-
-        return shapeLayer
-    }
-
-    func createInitialFlower(colors: [UIColor]) {
-        let numberOfCircles = colors.count
-        let radius: CGFloat = view.bounds.width / 6
-
-        for i in 0..<numberOfCircles {
-            let fillColor = colors[i]
-            let layer = drawCenteredFilledCircle(in: animationView, radius: radius, fillColor: fillColor)
-            circles.append(layer)
-        }
-    }
-
-
-    func animateOpenFlowerPetal(shapeLayer: CAShapeLayer, angle: CGFloat) {
-        let animation = CABasicAnimation(keyPath: "position")
-        animation.fromValue = shapeLayer.position
-        let distance = view.bounds.width / 6
-        animation.toValue = CGPoint(x: shapeLayer.position.x + distance * cos(angle), y: shapeLayer.position.y + distance * sin(angle))
-        animation.duration = Double(holdDuration) / 2
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        animation.fillMode = .forwards
-
-        animation.isRemovedOnCompletion = false
-        shapeLayer.add(animation, forKey: "flowerPetalOpenAnimation")
-    }
-
-    func animateCloseFlowerPetal(shapeLayer: CAShapeLayer, angle: CGFloat) {
-        let animation = CABasicAnimation(keyPath: "position")
-        let distance = view.bounds.width / 6
-        animation.fromValue = CGPoint(
-            x: shapeLayer.position.x + distance * cos(angle),
-            y: shapeLayer.position.y + distance * sin(angle)
-        )
-        animation.toValue = shapeLayer.position
-        animation.duration = Double(holdDuration) / 2
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        animation.fillMode = .forwards
-        animation.isRemovedOnCompletion = false
-
-        shapeLayer.add(animation, forKey: "flowerPetalCloseAnimation")
-    }
-
-    func openAllFlowerPetals() {
-        for (index, circle) in circles.enumerated() {
-            let angle = CGFloat(index) * (CGFloat.pi * 2 / CGFloat(circles.count))
-            animateOpenFlowerPetal(shapeLayer: circle, angle: angle)
-        }
-    }
-
-    func closeAllFlowerPetals() {
-        for (index, circle) in circles.enumerated() {
-            let angle = CGFloat(index) * (CGFloat.pi * 2 / CGFloat(circles.count))
-            animateCloseFlowerPetal(shapeLayer: circle, angle: angle)
-        }
-    }
-
+    
 }

--- a/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
@@ -59,7 +59,7 @@ class ExerciseViewController: UIViewController, UICollectionViewDelegate, UIColl
 //        if !exists {
 //            let exercises = await ContentHandler.shared.fetchExercises() ?? []
 //            MomCareUser.shared.user?.exercises = exercises
-//        }
+//        }rasxc
         let exercises = await ContentHandler.shared.fetchExercises() ?? []
         MomCareUser.shared.user?.exercises = exercises
         DispatchQueue.main.async {

--- a/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
+++ b/MomCare/Controllers/MyPlanControllers/Exercise/ExerciseViewController.swift
@@ -55,11 +55,13 @@ class ExerciseViewController: UIViewController, UICollectionViewDelegate, UIColl
     }
 
     func fetchExercises() async {
-        let exists = MomCareUser.shared.user?.exercises != nil && !(MomCareUser.shared.user?.exercises.isEmpty ?? true)
-        if !exists {
-            let exercises = await ContentHandler.shared.fetchExercises() ?? []
-            MomCareUser.shared.user?.exercises = exercises
-        }
+//        let exists = MomCareUser.shared.user?.exercises != nil && !(MomCareUser.shared.user?.exercises.isEmpty ?? true)
+//        if !exists {
+//            let exercises = await ContentHandler.shared.fetchExercises() ?? []
+//            MomCareUser.shared.user?.exercises = exercises
+//        }
+        let exercises = await ContentHandler.shared.fetchExercises() ?? []
+        MomCareUser.shared.user?.exercises = exercises
         DispatchQueue.main.async {
             self.myPlanViewController?.exercisesLoaded = true
             self.dataFetched = true

--- a/MomCare/Controllers/SignUpControllers/SignUpTableViewController.swift
+++ b/MomCare/Controllers/SignUpControllers/SignUpTableViewController.swift
@@ -26,7 +26,7 @@ class SignUpTableViewController: UITableViewController, UITextFieldDelegate {
         super.viewDidLoad()
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapGesture)
-
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
         firstNameField.becomeFirstResponder()
     }
 

--- a/MomCare/Controllers/TriTrackControllers/TriTrackAddEventViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackAddEventViewController.swift
@@ -44,6 +44,10 @@ class TriTrackAddEventViewController: UIViewController {
         super.viewWillAppear(animated)
         prepareContainerView()
     }
+    
+    override func viewDidLoad() {
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
+    }
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         switch segue.identifier {

--- a/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AddEventSegmentedView/AddEventTableViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AddEventSegmentedView/AddEventTableViewController.swift
@@ -57,7 +57,7 @@ class AddEventTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         endDateTimePicker.minimumDate = Date()
-
+        navigationController?.navigationBar.tintColor = UIColor(hex: "924350")
         preparePopupButtons()
     }
 

--- a/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Appointments/AllAppointmentsTableViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Appointments/AllAppointmentsTableViewController.swift
@@ -30,8 +30,31 @@ class AllAppointmentsTableViewController: UITableViewController {
         delegate.viewController = self
 
         tableView.sectionHeaderTopPadding = 10
-    }
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.systemBackground
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        appearance.shadowColor = .clear
 
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        let defaultAppearance = UINavigationBarAppearance()
+        defaultAppearance.configureWithOpaqueBackground()
+        defaultAppearance.backgroundColor = .systemBackground  // or whatever your default color is
+        defaultAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
+        defaultAppearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = defaultAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = defaultAppearance
+    }
+    override func viewDidLoad() {
+        setupAppointmentHeader()
+    }
     override func numberOfSections(in tableView: UITableView) -> Int {
         return groupedEvents.keys.count
     }
@@ -117,6 +140,32 @@ class AllAppointmentsTableViewController: UITableViewController {
             }
             groupedEvents[date]?.append(event)
         }
+    }
+    
+    private func setupAppointmentHeader() {
+        let headerLabel = UILabel()
+        headerLabel.text = "Appointments"
+        headerLabel.font = UIFont.systemFont(ofSize: 34, weight: .bold)
+        headerLabel.textColor = UIColor(hex: "924350")
+        headerLabel.textAlignment = .left
+        headerLabel.numberOfLines = 1
+        headerLabel.backgroundColor = .clear
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Calculate height for the label
+        let headerHeight: CGFloat = 60
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: headerHeight))
+        headerView.backgroundColor = .clear
+        headerView.addSubview(headerLabel)
+        
+        NSLayoutConstraint.activate([
+            headerLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
+            headerLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -16),
+            headerLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -15),
+            headerLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 8)
+        ])
+        
+        tableView.tableHeaderView = headerView
     }
 
 }

--- a/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Reminders/AllRemindersTableViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Reminders/AllRemindersTableViewController.swift
@@ -16,8 +16,28 @@ class AllRemindersTableViewController: UITableViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.systemBackground
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        appearance.shadowColor = .clear
 
-        fetchReminders()
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        setupRemindersHeader()
+        fetchAllReminders()
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        let defaultAppearance = UINavigationBarAppearance()
+        defaultAppearance.configureWithOpaqueBackground()
+        defaultAppearance.backgroundColor = .systemBackground  // or whatever your default color is
+        defaultAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
+        defaultAppearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = defaultAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = defaultAppearance
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -39,10 +59,35 @@ class AllRemindersTableViewController: UITableViewController {
     }
 
     // MARK: Private
-
-    private func fetchReminders() {
+    private func setupRemindersHeader() {
+        let headerLabel = UILabel()
+        headerLabel.text = "Reminders"
+        headerLabel.font = UIFont.systemFont(ofSize: 34, weight: .bold)
+        headerLabel.textColor = UIColor(hex: "924350")
+        headerLabel.textAlignment = .left
+        headerLabel.numberOfLines = 1
+        headerLabel.backgroundColor = .clear
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Calculate height for the label
+        let headerHeight: CGFloat = 60
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: headerHeight))
+        headerView.backgroundColor = .clear
+        headerView.addSubview(headerLabel)
+        
+        NSLayoutConstraint.activate([
+            headerLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
+            headerLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -16),
+            headerLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -15),
+            headerLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 8)
+        ])
+        
+        tableView.tableHeaderView = headerView
+    }
+    
+    private func fetchAllReminders() {
         Task {
-            await EventKitHandler.shared.fetchReminders { reminders in
+            await EventKitHandler.shared.fetchAllReminders { reminders in
                 DispatchQueue.main.async {
                     self.reminders = reminders
                     self.tableView.reloadData()
@@ -50,4 +95,5 @@ class AllRemindersTableViewController: UITableViewController {
             }
         }
     }
+
 }

--- a/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Symptoms/AllSymptomsTableViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/AllView/Symptoms/AllSymptomsTableViewController.swift
@@ -13,13 +13,37 @@ class AllSymptomsTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        setupSymptomsHeader() 
         Task {
             symptoms = await EventKitHandler.shared.fetchAllSymptoms()
             DispatchQueue.main.async {
                 self.tableView.reloadData()
             }
         }
+    }
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = UIColor.systemBackground
+        appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
+        appearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+    }
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        let defaultAppearance = UINavigationBarAppearance()
+        defaultAppearance.configureWithOpaqueBackground()
+        defaultAppearance.backgroundColor = .systemBackground
+        defaultAppearance.titleTextAttributes = [.foregroundColor: UIColor.label]
+        defaultAppearance.shadowColor = .clear
+
+        navigationController?.navigationBar.standardAppearance = defaultAppearance
+        navigationController?.navigationBar.scrollEdgeAppearance = defaultAppearance
     }
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -39,5 +63,31 @@ class AllSymptomsTableViewController: UITableViewController {
         cell.updateElements(with: symptoms[indexPath.row])
 
         return cell
+    }
+    
+    private func setupSymptomsHeader() {
+        let headerLabel = UILabel()
+        headerLabel.text = "Symptoms"
+        headerLabel.font = UIFont.systemFont(ofSize: 34, weight: .bold)
+        headerLabel.textColor = UIColor(hex: "924350")
+        headerLabel.textAlignment = .left
+        headerLabel.numberOfLines = 1
+        headerLabel.backgroundColor = .clear
+        headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Calculate height for the label
+        let headerHeight: CGFloat = 60
+        let headerView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.bounds.width, height: headerHeight))
+        headerView.backgroundColor = .clear
+        headerView.addSubview(headerLabel)
+        
+        NSLayoutConstraint.activate([
+            headerLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 16),
+            headerLabel.trailingAnchor.constraint(equalTo: headerView.trailingAnchor, constant: -16),
+            headerLabel.bottomAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -15),
+            headerLabel.topAnchor.constraint(equalTo: headerView.topAnchor, constant: 8)
+        ])
+        
+        tableView.tableHeaderView = headerView
     }
 }

--- a/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/MainSegmentedView/Appointments/AppointmentsTableViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackTableControllers/MainSegmentedView/Appointments/AppointmentsTableViewController.swift
@@ -101,7 +101,7 @@ class AppointmentsTableViewController: UITableViewController {
     func fetchEvents() async -> [EventInfo] {
         let selectedDate = eventsViewController?.triTrackViewController?.selectedFSCalendarDate ?? Date()
         let startDate = Calendar.current.startOfDay(for: selectedDate)
-        let endDate = Calendar.current.date(byAdding: .day, value: 1, to: startDate)!
+        let endDate = Calendar.current.date(byAdding: .month, value: 1, to: startDate)!
 
         return await EventKitHandler.shared.fetchAppointments(startDate: startDate, endDate: endDate)
     }

--- a/MomCare/Controllers/TriTrackControllers/TriTrackViewController/TriTrackViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackViewController/TriTrackViewController.swift
@@ -47,14 +47,13 @@ class TriTrackViewController: UIViewController, FSCalendarDelegate, FSCalendarDa
             await EventKitHandler.shared.requestAccessForEvent()
             await EventKitHandler.shared.requestAccessForReminder()
         }
-
+        navigationController?.navigationBar.tintColor = UIColor(hex: "#924350")
         navigationController?.navigationBar.isTranslucent = false
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         triTrackInternalView.layer.cornerRadius = 15
-
         prepareSegmentedControl()
         updateView(with: currentSegmentValue)
     }

--- a/MomCare/Controllers/TriTrackControllers/TriTrackViewController/TriTrackViewController.swift
+++ b/MomCare/Controllers/TriTrackControllers/TriTrackViewController/TriTrackViewController.swift
@@ -120,8 +120,10 @@ class TriTrackViewController: UIViewController, FSCalendarDelegate, FSCalendarDa
 
         fsCalendarView.dataSource = self
         fsCalendarView.delegate = self
-        // TODO: @aryansingh
-
+        fsCalendarView.appearance.selectionColor = UIColor(hex: "#924350")
+        fsCalendarView.appearance.weekdayTextColor = .darkGray
+        fsCalendarView.appearance.headerTitleColor = .darkGray
+        fsCalendarView.appearance.titleDefaultColor = .darkGray
         calendarUIView.addSubview(fsCalendarView)
     }
 }

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="E6r-mj-UOM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="E6r-mj-UOM">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -24,7 +24,7 @@
             <objects>
                 <tableViewController id="sbk-e6-TqC" customClass="ProfilePageTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="6zi-5r-6SN">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="Qxv-dF-9bc">
@@ -448,7 +448,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="3fr-wh-mP1">
-                                <rect key="frame" x="0.0" y="155" width="393" height="663"/>
+                                <rect key="frame" x="0.0" y="214" width="393" height="570"/>
                                 <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="4ns-fZ-ftx">
                                     <size key="itemSize" width="128" height="128"/>
@@ -484,7 +484,7 @@
             <objects>
                 <tableViewController id="6pk-4K-jTX" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="qQG-sQ-Qdr">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -517,7 +517,7 @@
             <objects>
                 <tableViewController id="oO8-UD-jq3" customClass="SettingsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="nkm-2N-2YP">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection headerTitle="Account Info" id="fop-Yf-CMm">
@@ -698,7 +698,7 @@
             <objects>
                 <tableViewController id="fdG-o2-OuS" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="quF-hh-EqY">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -747,7 +747,7 @@
             <objects>
                 <tableViewController id="bEA-sz-osd" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="8eb-gd-KVi">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -795,35 +795,43 @@
         <scene sceneID="QvT-ER-eg1">
             <objects>
                 <tableViewController id="vRm-CM-3k7" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="uzz-D1-7sb">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="uzz-D1-7sb">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
                             <tableViewSection id="qmO-6J-Yj5">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="EXN-Mw-k6b">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="18" width="353" height="50.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EXN-Mw-k6b" id="0pG-In-N4D">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="50.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="tr0-8Z-b6t">
-                                        <rect key="frame" x="0.0" y="93.666667938232422" width="393" height="43.666667938232422"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tr0-8Z-b6t" id="Kzn-XD-RZ0">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Vzr-nb-3K4">
-                                        <rect key="frame" x="0.0" y="137.33333587646484" width="393" height="43.666667938232422"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vzr-nb-3K4" id="h40-q1-6CQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="W90-s8-v0x">
+                                                    <rect key="frame" x="16" y="8" width="321" height="34.666666666666664"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Delete Account" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vo3-cC-j7Y">
+                                                            <rect key="frame" x="0.0" y="0.0" width="116.66666666666667" height="34.666666666666664"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="p9L-Xz-tPm">
+                                                            <rect key="frame" x="247.66666666666671" y="0.0" width="73.333333333333343" height="34.666666666666664"/>
+                                                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <state key="normal" title="Button"/>
+                                                            <buttonConfiguration key="configuration" style="plain" title="Delete"/>
+                                                        </button>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="W90-s8-v0x" secondAttribute="bottom" constant="8" id="HDf-BT-IRT"/>
+                                                <constraint firstItem="W90-s8-v0x" firstAttribute="top" secondItem="0pG-In-N4D" secondAttribute="top" constant="8" id="LLB-wj-8Ma"/>
+                                                <constraint firstAttribute="trailing" secondItem="W90-s8-v0x" secondAttribute="trailing" constant="16" id="ftA-UI-9gu"/>
+                                                <constraint firstItem="W90-s8-v0x" firstAttribute="leading" secondItem="0pG-In-N4D" secondAttribute="leading" constant="16" id="fwX-jK-HoL"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -845,7 +853,7 @@
             <objects>
                 <tableViewController id="Oih-TT-hif" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="25" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="kc9-v5-C7z">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="zeF-Ra-jTD">
@@ -907,7 +915,7 @@
             <objects>
                 <tableViewController id="Fti-hv-RJM" customClass="HealthDetailsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="ASv-8J-DP9">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="bSe-Ik-wcB">
@@ -964,6 +972,7 @@
                                                         </label>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1ju-Dr-mx1">
                                                             <rect key="frame" x="194.33333333333334" y="0.0" width="108.33333333333334" height="55"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -1005,6 +1014,7 @@
                                                         </label>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yFy-ha-quh">
                                                             <rect key="frame" x="196.66666666666666" y="0.0" width="105.99999999999997" height="55"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -1046,6 +1056,7 @@
                                                         </label>
                                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bwm-fg-idG">
                                                             <rect key="frame" x="134.66666666666666" y="0.0" width="167.99999999999997" height="55"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
@@ -1075,6 +1086,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Health Information" id="2gV-6z-aXa">
                         <barButtonItem key="rightBarButtonItem" title="Edit" style="done" id="uf6-8L-dFs">
+                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
                                 <action selector="editButtonTapped:" destination="Fti-hv-RJM" id="Ogc-mn-ywx"/>
                             </connections>
@@ -1107,7 +1119,7 @@
             <objects>
                 <tableViewController id="4dk-vA-dKF" customClass="PersonalDetailsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="nJ0-pn-axl">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
                             <tableViewSection id="WBb-4z-ZJ4">
@@ -1192,7 +1204,7 @@
                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="xJK-sC-qnN">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DOB" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="obr-Wg-WfQ">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date of Birth" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="obr-Wg-WfQ">
                                                             <rect key="frame" x="0.0" y="12.333333333333334" width="156.66666666666666" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
@@ -1212,225 +1224,239 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="bot-vP-GwP">
-                                        <rect key="frame" x="20" y="224.33333587646484" width="353" height="45"/>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="gvi-rS-xFL">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="EYf-Aq-XOo">
+                                        <rect key="frame" x="20" y="260.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bot-vP-GwP" id="SBL-0F-ftc">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EYf-Aq-XOo" id="Srh-Ea-1MZ">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="HCc-Ce-2yb">
+                                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="W0P-w1-GS2">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Height" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7uG-RV-UOw">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Height" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MMI-XC-lH5">
                                                             <rect key="frame" x="0.0" y="0.0" width="156.66666666666666" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DL1-df-SM3">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWf-YU-hF8">
                                                             <rect key="frame" x="156.66666666666663" y="0.0" width="156.33333333333337" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="r4U-No-UQJ"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="x0g-0g-1If"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="HCc-Ce-2yb" firstAttribute="leading" secondItem="SBL-0F-ftc" secondAttribute="leading" constant="20" symbolic="YES" id="4vn-we-uWJ"/>
-                                                <constraint firstItem="HCc-Ce-2yb" firstAttribute="top" secondItem="SBL-0F-ftc" secondAttribute="top" id="kNn-vF-zGx"/>
-                                                <constraint firstAttribute="bottom" secondItem="HCc-Ce-2yb" secondAttribute="bottom" id="pjM-Mp-geB"/>
-                                                <constraint firstAttribute="trailing" secondItem="HCc-Ce-2yb" secondAttribute="trailing" constant="20" symbolic="YES" id="ttZ-be-s4m"/>
+                                                <constraint firstItem="W0P-w1-GS2" firstAttribute="leading" secondItem="Srh-Ea-1MZ" secondAttribute="leading" constant="20" symbolic="YES" id="63T-4p-DL0"/>
+                                                <constraint firstAttribute="trailing" secondItem="W0P-w1-GS2" secondAttribute="trailing" constant="20" symbolic="YES" id="Dep-q1-m1f"/>
+                                                <constraint firstAttribute="bottom" secondItem="W0P-w1-GS2" secondAttribute="bottom" id="Vcx-mb-loC"/>
+                                                <constraint firstItem="W0P-w1-GS2" firstAttribute="top" secondItem="Srh-Ea-1MZ" secondAttribute="top" id="wsW-0h-gux"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="Re5-oT-Equ">
-                                        <rect key="frame" x="20" y="269.33333587646484" width="353" height="45"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="Rxk-gV-l27">
+                                        <rect key="frame" x="20" y="305.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Re5-oT-Equ" id="1f9-PZ-5Vh">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rxk-gV-l27" id="Pbo-SK-ULq">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="08U-KH-yPI">
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jGa-2o-B7R">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cqk-3y-nBO">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Current Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XUZ-db-ICg">
                                                             <rect key="frame" x="0.0" y="0.0" width="115.66666666666667" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3sX-Uv-huM">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nep-g2-4cz">
                                                             <rect key="frame" x="115.66666666666664" y="0.0" width="197.33333333333337" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="wbw-RJ-H1w"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="lak-nW-T9g"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="08U-KH-yPI" secondAttribute="trailing" constant="20" symbolic="YES" id="Ubd-9Z-4BI"/>
-                                                <constraint firstItem="08U-KH-yPI" firstAttribute="top" secondItem="1f9-PZ-5Vh" secondAttribute="top" id="bnv-SU-sLk"/>
-                                                <constraint firstAttribute="bottom" secondItem="08U-KH-yPI" secondAttribute="bottom" id="c6E-rc-1FT"/>
-                                                <constraint firstItem="08U-KH-yPI" firstAttribute="leading" secondItem="1f9-PZ-5Vh" secondAttribute="leading" constant="20" symbolic="YES" id="sQB-Pv-hcR"/>
+                                                <constraint firstItem="jGa-2o-B7R" firstAttribute="leading" secondItem="Pbo-SK-ULq" secondAttribute="leading" constant="20" symbolic="YES" id="8kL-vi-aHr"/>
+                                                <constraint firstItem="jGa-2o-B7R" firstAttribute="top" secondItem="Pbo-SK-ULq" secondAttribute="top" id="LVh-J9-6DE"/>
+                                                <constraint firstAttribute="bottom" secondItem="jGa-2o-B7R" secondAttribute="bottom" id="XBb-PN-K8T"/>
+                                                <constraint firstAttribute="trailing" secondItem="jGa-2o-B7R" secondAttribute="trailing" constant="20" symbolic="YES" id="hdi-au-oBM"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="WiT-Zf-EPc">
-                                        <rect key="frame" x="20" y="314.33333587646484" width="353" height="45"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="D0x-ae-arD">
+                                        <rect key="frame" x="20" y="350.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WiT-Zf-EPc" id="PMn-oW-rP2">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="D0x-ae-arD" id="5QE-OE-Tq5">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ALh-j6-aDc">
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MPZ-HW-DJ2">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pre Pregnancy Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KyL-h9-nRA">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Pre Pregnancy Weight" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qej-uE-UAV">
                                                             <rect key="frame" x="0.0" y="0.0" width="169" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2sJ-WY-ViJ">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CZz-wb-T2R">
                                                             <rect key="frame" x="169" y="0.0" width="144" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="XEk-qw-KSW"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="dEb-pJ-PZ1"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="ALh-j6-aDc" secondAttribute="trailing" constant="20" symbolic="YES" id="QX9-Tb-nPb"/>
-                                                <constraint firstAttribute="bottom" secondItem="ALh-j6-aDc" secondAttribute="bottom" id="eAY-3U-GYK"/>
-                                                <constraint firstItem="ALh-j6-aDc" firstAttribute="leading" secondItem="PMn-oW-rP2" secondAttribute="leading" constant="20" symbolic="YES" id="eFc-6d-UhF"/>
-                                                <constraint firstItem="ALh-j6-aDc" firstAttribute="top" secondItem="PMn-oW-rP2" secondAttribute="top" id="wL9-bE-vYb"/>
+                                                <constraint firstAttribute="bottom" secondItem="MPZ-HW-DJ2" secondAttribute="bottom" id="GtK-B9-JUP"/>
+                                                <constraint firstAttribute="trailing" secondItem="MPZ-HW-DJ2" secondAttribute="trailing" constant="20" symbolic="YES" id="Lxh-Rr-IwG"/>
+                                                <constraint firstItem="MPZ-HW-DJ2" firstAttribute="top" secondItem="5QE-OE-Tq5" secondAttribute="top" id="PVe-22-9Uv"/>
+                                                <constraint firstItem="MPZ-HW-DJ2" firstAttribute="leading" secondItem="5QE-OE-Tq5" secondAttribute="leading" constant="20" symbolic="YES" id="cxr-8R-5TP"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="xu4-3P-AZO">
-                                        <rect key="frame" x="20" y="359.33333587646484" width="353" height="45"/>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="431-tz-ZXV">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="y4a-PC-Flj">
+                                        <rect key="frame" x="20" y="431.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xu4-3P-AZO" id="FMC-N4-JT3">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="y4a-PC-Flj" id="iHn-pL-ubJ">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b3h-M0-gcJ">
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kcf-c0-OQe">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wnT-B4-Grh">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Day" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aMW-bI-J48">
                                                             <rect key="frame" x="0.0" y="0.0" width="29.666666666666668" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UOl-9i-ZAh">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kgi-nl-piE">
                                                             <rect key="frame" x="29.666666666666657" y="0.0" width="283.33333333333337" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="aKw-QU-ubi"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="Wpu-aQ-QVf"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="trailing" secondItem="b3h-M0-gcJ" secondAttribute="trailing" constant="20" symbolic="YES" id="Bwo-BG-RO8"/>
-                                                <constraint firstAttribute="bottom" secondItem="b3h-M0-gcJ" secondAttribute="bottom" id="KvQ-BN-a0D"/>
-                                                <constraint firstItem="b3h-M0-gcJ" firstAttribute="top" secondItem="FMC-N4-JT3" secondAttribute="top" id="RIr-dy-OEe"/>
-                                                <constraint firstItem="b3h-M0-gcJ" firstAttribute="leading" secondItem="FMC-N4-JT3" secondAttribute="leading" constant="20" symbolic="YES" id="bOe-FT-sK3"/>
+                                                <constraint firstAttribute="trailing" secondItem="Kcf-c0-OQe" secondAttribute="trailing" constant="20" symbolic="YES" id="GbW-q4-tnV"/>
+                                                <constraint firstItem="Kcf-c0-OQe" firstAttribute="top" secondItem="iHn-pL-ubJ" secondAttribute="top" id="ipr-6T-J30"/>
+                                                <constraint firstItem="Kcf-c0-OQe" firstAttribute="leading" secondItem="iHn-pL-ubJ" secondAttribute="leading" constant="20" symbolic="YES" id="ss8-pr-dpe"/>
+                                                <constraint firstAttribute="bottom" secondItem="Kcf-c0-OQe" secondAttribute="bottom" id="uB4-2t-2w3"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="fKA-d8-aMD">
-                                        <rect key="frame" x="20" y="404.33333587646484" width="353" height="45"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="ZIH-NI-Ztt">
+                                        <rect key="frame" x="20" y="476.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fKA-d8-aMD" id="1qf-qO-v3Z">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZIH-NI-Ztt" id="LoP-3r-VMB">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="V4i-Oi-vAb">
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZWI-y0-sgs">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Week" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="X7Z-U4-WkF">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Week" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NWn-lC-9gt">
                                                             <rect key="frame" x="0.0" y="0.0" width="42.666666666666664" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7wA-In-p7P">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7QR-V2-xAE">
                                                             <rect key="frame" x="42.666666666666657" y="0.0" width="270.33333333333337" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="WgP-q7-yZc"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="c4E-qY-Ous"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="V4i-Oi-vAb" firstAttribute="leading" secondItem="1qf-qO-v3Z" secondAttribute="leading" constant="20" symbolic="YES" id="4VL-iC-UMj"/>
-                                                <constraint firstAttribute="trailing" secondItem="V4i-Oi-vAb" secondAttribute="trailing" constant="20" symbolic="YES" id="BYl-Xy-qOu"/>
-                                                <constraint firstItem="V4i-Oi-vAb" firstAttribute="top" secondItem="1qf-qO-v3Z" secondAttribute="top" id="EOX-Ry-RyQ"/>
-                                                <constraint firstAttribute="bottom" secondItem="V4i-Oi-vAb" secondAttribute="bottom" id="PYe-Lf-bVu"/>
+                                                <constraint firstItem="ZWI-y0-sgs" firstAttribute="top" secondItem="LoP-3r-VMB" secondAttribute="top" id="Jxo-Yt-l8R"/>
+                                                <constraint firstItem="ZWI-y0-sgs" firstAttribute="leading" secondItem="LoP-3r-VMB" secondAttribute="leading" constant="20" symbolic="YES" id="N3j-Lc-vKv"/>
+                                                <constraint firstAttribute="trailing" secondItem="ZWI-y0-sgs" secondAttribute="trailing" constant="20" symbolic="YES" id="RPf-Zg-J5q"/>
+                                                <constraint firstAttribute="bottom" secondItem="ZWI-y0-sgs" secondAttribute="bottom" id="feE-x1-r8j"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="c6L-6I-N5H">
-                                        <rect key="frame" x="20" y="449.33333587646484" width="353" height="45"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="RDt-8F-sPi">
+                                        <rect key="frame" x="20" y="521.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="c6L-6I-N5H" id="bHs-eL-52f">
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RDt-8F-sPi" id="mlM-Ao-O5M">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WKJ-y3-iMA">
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NCy-YP-uVp">
                                                     <rect key="frame" x="20" y="0.0" width="313" height="45"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trimester" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8ZF-tS-xR1">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Trimester" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Drp-x1-avH">
                                                             <rect key="frame" x="0.0" y="0.0" width="72" height="45"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kdj-XY-5Wc">
+                                                        <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fXN-t2-SZI">
                                                             <rect key="frame" x="72" y="0.0" width="241" height="45"/>
+                                                            <color key="tintColor" systemColor="secondaryLabelColor"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" title="Not Set">
                                                                 <fontDescription key="titleFontDescription" style="UICTFontTextStyleSubhead"/>
                                                             </buttonConfiguration>
                                                             <connections>
-                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="pe4-VO-ii4"/>
+                                                                <action selector="fieldValuesButtonTapped:" destination="4dk-vA-dKF" eventType="touchUpInside" id="uOG-FS-4A0"/>
                                                             </connections>
                                                         </button>
                                                     </subviews>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="WKJ-y3-iMA" secondAttribute="bottom" id="09s-gX-6bG"/>
-                                                <constraint firstItem="WKJ-y3-iMA" firstAttribute="leading" secondItem="bHs-eL-52f" secondAttribute="leading" constant="20" symbolic="YES" id="Cb5-aL-R7d"/>
-                                                <constraint firstItem="WKJ-y3-iMA" firstAttribute="top" secondItem="bHs-eL-52f" secondAttribute="top" id="J8M-MW-ubc"/>
-                                                <constraint firstAttribute="trailing" secondItem="WKJ-y3-iMA" secondAttribute="trailing" constant="20" symbolic="YES" id="W4R-Fy-85T"/>
+                                                <constraint firstItem="NCy-YP-uVp" firstAttribute="top" secondItem="mlM-Ao-O5M" secondAttribute="top" id="1C4-Ec-d5R"/>
+                                                <constraint firstAttribute="trailing" secondItem="NCy-YP-uVp" secondAttribute="trailing" constant="20" symbolic="YES" id="Kod-jB-my8"/>
+                                                <constraint firstAttribute="bottom" secondItem="NCy-YP-uVp" secondAttribute="bottom" id="fDd-a2-4GX"/>
+                                                <constraint firstItem="NCy-YP-uVp" firstAttribute="leading" secondItem="mlM-Ao-O5M" secondAttribute="leading" constant="20" symbolic="YES" id="jEE-XB-kZA"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -1444,20 +1470,21 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Personal Information" id="fSx-GN-9fR">
                         <barButtonItem key="rightBarButtonItem" title="Edit" style="done" id="JCM-oP-LW2">
+                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
                                 <action selector="editButtonTapped:" destination="4dk-vA-dKF" id="j8Y-oy-Tjb"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
                     <connections>
-                        <outlet property="userCurrentWeightButton" destination="3sX-Uv-huM" id="5WO-Ib-C7G"/>
+                        <outlet property="userCurrentWeightButton" destination="Nep-g2-4cz" id="mSZ-hZ-mfc"/>
                         <outlet property="userDatOfBirthPicker" destination="IBk-Q3-oeJ" id="BTX-5d-oMO"/>
-                        <outlet property="userHeightButton" destination="DL1-df-SM3" id="2F7-eA-hPt"/>
+                        <outlet property="userHeightButton" destination="LWf-YU-hF8" id="UQ0-1q-nk0"/>
                         <outlet property="userNameField" destination="JeD-uj-YeP" id="x5n-ZF-U3c"/>
-                        <outlet property="userPrePregnancyWeightButton" destination="2sJ-WY-ViJ" id="nNB-t1-1sf"/>
-                        <outlet property="userPregnancyDayButton" destination="UOl-9i-ZAh" id="5TV-m8-HSh"/>
-                        <outlet property="userPregnancyWeekButton" destination="7wA-In-p7P" id="37e-23-Tgf"/>
-                        <outlet property="userTrimesterButton" destination="Kdj-XY-5Wc" id="MF8-G8-R81"/>
+                        <outlet property="userPrePregnancyWeightButton" destination="CZz-wb-T2R" id="DGp-ut-Zye"/>
+                        <outlet property="userPregnancyDayButton" destination="kgi-nl-piE" id="hhA-du-AQT"/>
+                        <outlet property="userPregnancyWeekButton" destination="7QR-V2-xAE" id="TD6-wB-MRQ"/>
+                        <outlet property="userTrimesterButton" destination="fXN-t2-SZI" id="szc-kp-uSu"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gYL-Mc-ioF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -1510,7 +1537,7 @@
                     </tabBarItem>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="ovL-Il-4Km">
-                        <rect key="frame" x="0.0" y="59" width="393" height="96"/>
+                        <rect key="frame" x="0.0" y="118" width="393" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -1536,14 +1563,17 @@
         <systemColor name="groupTableViewBackgroundColor">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -537,7 +537,7 @@
         <!--Account & Security-->
         <scene sceneID="0FX-O9-Fl2">
             <objects>
-                <tableViewController id="oO8-UD-jq3" customClass="SettingsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="oO8-UD-jq3" customClass="ProfileSecurityTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="nkm-2N-2YP">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -842,10 +842,43 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="Health &amp; Support" id="dSS-qZ-fSl"/>
+                    <connections>
+                        <segue destination="LW8-m1-C9D" kind="show" id="BVw-oA-69X"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ygm-ai-Qu6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="3473" y="154"/>
+        </scene>
+        <!--PrivacyPolicyTableViewController-->
+        <scene sceneID="vgK-JP-toM">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="PrivacyPolicyTableViewController" storyboardName="LegalComplianceStoryboard" referencedIdentifier="PrivacyPolicyTableViewController" id="Je2-8K-XBj" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="VSG-u8-NUi"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qMc-WM-2Xu" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2254" y="568"/>
+        </scene>
+        <!--TermsOfServiceTableViewController-->
+        <scene sceneID="pjR-Vq-3xj">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="TermsOfServiceTableViewController" storyboardName="LegalComplianceStoryboard" referencedIdentifier="TermsOfServiceTableViewController" id="AJD-dC-qF7" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="uVc-HF-O9C"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XrK-wL-tNr" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2476" y="606"/>
+        </scene>
+        <!--Storyboard Reference-->
+        <scene sceneID="FoV-f7-utM">
+            <objects>
+                <viewControllerPlaceholder id="LW8-m1-C9D" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="nu3-Bd-zNv"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6IY-Bu-In9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3473" y="559"/>
         </scene>
         <!--About MomCare+-->
         <scene sceneID="dWw-gU-awI">
@@ -970,10 +1003,23 @@
                         </connections>
                     </tableView>
                     <navigationItem key="navigationItem" title="About MomCare+" id="3uf-0d-UWj"/>
+                    <connections>
+                        <segue destination="Aah-q2-hTU" kind="show" id="45g-hM-0Tt"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="uyl-cx-0rC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4269" y="132"/>
+        </scene>
+        <!--Storyboard Reference-->
+        <scene sceneID="PEi-Ps-b3x">
+            <objects>
+                <viewControllerPlaceholder id="Aah-q2-hTU" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="0SR-JB-9wJ"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Nqj-Od-Rja" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4268" y="569"/>
         </scene>
         <!--Account Management-->
         <scene sceneID="QvT-ER-eg1">
@@ -1035,7 +1081,7 @@
         <!--Legal & Compliance-->
         <scene sceneID="YNF-Yn-YEs">
             <objects>
-                <tableViewController id="Oih-TT-hif" sceneMemberID="viewController">
+                <tableViewController id="Oih-TT-hif" customClass="LegalComplianceTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="25" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="kc9-v5-C7z">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -1066,6 +1112,9 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <connections>
+                                            <segue destination="Je2-8K-XBj" kind="show" identifier="PrivacyPolicySegue" trigger="accessoryAction" id="BMH-rR-Hch"/>
+                                        </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="d8b-2R-gy9" detailTextLabel="B1P-Mh-A2y" style="IBUITableViewCellStyleValue1" id="PbD-qz-fel">
                                         <rect key="frame" x="20" y="68.666667938232422" width="353" height="43.666667938232422"/>
@@ -1091,6 +1140,9 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <connections>
+                                            <segue destination="AJD-dC-qF7" kind="show" identifier="TermsOfServiceSegue" trigger="accessoryAction" id="j62-yP-pFF"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -1482,7 +1534,7 @@
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JeD-uj-YeP">
+                                                        <textField opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Sample" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="JeD-uj-YeP">
                                                             <rect key="frame" x="156.66666666666663" y="11.666666666666664" width="156.33333333333337" height="22"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <textInputTraits key="textInputTraits"/>

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -752,25 +752,18 @@
                         <sections>
                             <tableViewSection id="4y4-2f-05b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="GXx-g4-NbA" detailTextLabel="DFa-jV-f3o" style="IBUITableViewCellStyleValue1" id="UxH-SB-1JA">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="GXx-g4-NbA" style="IBUITableViewCellStyleDefault" id="UxH-SB-1JA">
                                         <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UxH-SB-1JA" id="JbR-vl-Ajw">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="FAQ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GXx-g4-NbA">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="33" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DFa-jV-f3o">
-                                                    <rect key="frame" x="245.66666666666669" y="11.999999999999998" width="37" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -778,25 +771,18 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" editingAccessoryType="detailDisclosureButton" textLabel="G6D-b0-zlA" detailTextLabel="dGC-qZ-aLa" style="IBUITableViewCellStyleValue1" id="AiD-R1-fj9">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" editingAccessoryType="detailDisclosureButton" textLabel="G6D-b0-zlA" style="IBUITableViewCellStyleDefault" id="AiD-R1-fj9">
                                         <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AiD-R1-fj9" id="IoH-3L-CrQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Contact Support" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="G6D-b0-zlA">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="132" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Get Help" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dGC-qZ-aLa">
-                                                    <rect key="frame" x="215.66666666666669" y="11.999999999999998" width="67" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -808,25 +794,18 @@
                             </tableViewSection>
                             <tableViewSection id="s5E-oz-sMZ">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="BPU-bt-Eev" detailTextLabel="kHl-v7-Fa2" style="IBUITableViewCellStyleValue1" id="NZG-gH-RhH">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="BPU-bt-Eev" style="IBUITableViewCellStyleDefault" id="NZG-gH-RhH">
                                         <rect key="frame" x="20" y="141.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="NZG-gH-RhH" id="CRj-ik-v2q">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BPU-bt-Eev">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="78" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Share" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kHl-v7-Fa2">
-                                                    <rect key="frame" x="238.66666666666669" y="11.999999999999998" width="44" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -891,25 +870,18 @@
                         <sections>
                             <tableViewSection id="baV-II-XHP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="hDz-ke-Z4t" detailTextLabel="8zg-CE-fTf" style="IBUITableViewCellStyleValue1" id="Dcs-cn-bBO">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="hDz-ke-Z4t" style="IBUITableViewCellStyleDefault" id="Dcs-cn-bBO">
                                         <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcs-cn-bBO" id="IYH-Nt-AxA">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="About Us" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hDz-ke-Z4t">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="73.666666666666671" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Our Story" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8zg-CE-fTf">
-                                                    <rect key="frame" x="209.33333333333337" y="11.999999999999998" width="73.333333333333329" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -944,50 +916,36 @@
                             </tableViewSection>
                             <tableViewSection id="GvB-04-mH6">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="Kad-hr-dev" detailTextLabel="mmV-UB-cfy" style="IBUITableViewCellStyleValue1" id="JRe-yW-4tq">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Kad-hr-dev" style="IBUITableViewCellStyleDefault" id="JRe-yW-4tq">
                                         <rect key="frame" x="20" y="141.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JRe-yW-4tq" id="s78-xC-OZR">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Credits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kad-hr-dev">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="58" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mmV-UB-cfy">
-                                                    <rect key="frame" x="239.00000000000003" y="11.999999999999998" width="43.666666666666664" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="y0T-au-34h" detailTextLabel="r3o-HH-wV4" style="IBUITableViewCellStyleValue1" id="Xwe-jl-ok6">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="y0T-au-34h" style="IBUITableViewCellStyleDefault" id="Xwe-jl-ok6">
                                         <rect key="frame" x="20" y="185.00000381469727" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xwe-jl-ok6" id="7pm-YL-hKT">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open Source" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="y0T-au-34h">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="103" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Licenses" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r3o-HH-wV4">
-                                                    <rect key="frame" x="215.33333333333337" y="11.999999999999998" width="67.333333333333329" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -1088,110 +1046,82 @@
                         <sections>
                             <tableViewSection id="zeF-Ra-jTD">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ViH-ko-BjP" detailTextLabel="VfV-OR-PNH" style="IBUITableViewCellStyleValue1" id="pNB-FW-ViT">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ViH-ko-BjP" style="IBUITableViewCellStyleDefault" id="pNB-FW-ViT">
                                         <rect key="frame" x="20" y="25" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pNB-FW-ViT" id="6K6-UT-2j6">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy Policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ViH-ko-BjP">
-                                                    <rect key="frame" x="20.000000000000007" y="11.999999999999998" width="110.66666666666667" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Policy" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VfV-OR-PNH">
-                                                    <rect key="frame" x="237.33333333333334" y="11.999999999999998" width="45.333333333333336" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
-                                            <segue destination="Je2-8K-XBj" kind="show" identifier="PrivacyPolicySegue" trigger="accessoryAction" id="BMH-rR-Hch"/>
+                                            <segue destination="Je2-8K-XBj" kind="show" id="9rL-0m-N5Z"/>
                                         </connections>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="d8b-2R-gy9" detailTextLabel="B1P-Mh-A2y" style="IBUITableViewCellStyleValue1" id="PbD-qz-fel">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="d8b-2R-gy9" style="IBUITableViewCellStyleDefault" id="PbD-qz-fel">
                                         <rect key="frame" x="20" y="68.666667938232422" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PbD-qz-fel" id="hnJ-Xo-0P0">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms of Service" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d8b-2R-gy9">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="133.33333333333334" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="B1P-Mh-A2y">
-                                                    <rect key="frame" x="235.66666666666669" y="11.999999999999998" width="47" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <connections>
-                                            <segue destination="AJD-dC-qF7" kind="show" identifier="TermsOfServiceSegue" trigger="accessoryAction" id="j62-yP-pFF"/>
+                                            <segue destination="AJD-dC-qF7" kind="show" id="ni0-23-etg"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection id="DTw-FY-Lae">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="XI6-oJ-FsQ" detailTextLabel="bgg-vo-V7o" style="IBUITableViewCellStyleValue1" id="ahf-a6-svM">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="XI6-oJ-FsQ" style="IBUITableViewCellStyleDefault" id="ahf-a6-svM">
                                         <rect key="frame" x="20" y="155.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ahf-a6-svM" id="lgc-ng-Vqg">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Code of Conduct" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XI6-oJ-FsQ">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="134.33333333333334" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bgg-vo-V7o">
-                                                    <rect key="frame" x="245.66666666666669" y="11.999999999999998" width="37" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="2XT-K9-Eox" detailTextLabel="UHa-Ou-XjL" style="IBUITableViewCellStyleValue1" id="Alu-PA-TDc">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="2XT-K9-Eox" style="IBUITableViewCellStyleDefault" id="Alu-PA-TDc">
                                         <rect key="frame" x="20" y="199.00000381469727" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Alu-PA-TDc" id="7lj-j0-no1">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Cookie Policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2XT-K9-Eox">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="107" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UHa-Ou-XjL">
-                                                    <rect key="frame" x="239.00000000000003" y="11.999999999999998" width="43.666666666666664" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
@@ -1202,50 +1132,36 @@
                             </tableViewSection>
                             <tableViewSection id="uS6-MY-nUD">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="uPb-wg-0fi" detailTextLabel="Fjh-7o-Ukc" style="IBUITableViewCellStyleValue1" id="cOc-x6-P19">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="uPb-wg-0fi" style="IBUITableViewCellStyleDefault" id="cOc-x6-P19">
                                         <rect key="frame" x="20" y="285.66667175292969" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cOc-x6-P19" id="7sK-BR-5mb">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Data Usage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uPb-wg-0fi">
-                                                    <rect key="frame" x="20" y="11.999999999999998" width="92" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Learn More" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Fjh-7o-Ukc">
-                                                    <rect key="frame" x="196.33333333333337" y="11.999999999999998" width="86.333333333333329" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bY7-1E-SD8" detailTextLabel="tCb-Lw-lt1" style="IBUITableViewCellStyleValue1" id="lum-ov-nS0">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bY7-1E-SD8" style="IBUITableViewCellStyleDefault" id="lum-ov-nS0">
                                         <rect key="frame" x="20" y="329.33333969116211" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lum-ov-nS0" id="xdT-Pg-wy6">
-                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="GDPR Rights" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bY7-1E-SD8">
-                                                    <rect key="frame" x="19.999999999999993" y="11.999999999999998" width="101.33333333333333" height="20.333333333333332"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Your Rights" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tCb-Lw-lt1">
-                                                    <rect key="frame" x="195.66666666666669" y="11.999999999999998" width="87" height="20.333333333333332"/>
+                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -17,7 +17,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2FZ-Xn-H2s" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2302" y="-870"/>
+            <point key="canvasLocation" x="2189" y="-947"/>
         </scene>
         <!--Profile-->
         <scene sceneID="5sY-3Z-DA8">

--- a/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/Dashboard.storyboard
@@ -483,19 +483,41 @@
         <scene sceneID="qGn-Hg-LCO">
             <objects>
                 <tableViewController id="6pk-4K-jTX" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="qQG-sQ-Qdr">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="qQG-sQ-Qdr">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <sections>
                             <tableViewSection id="wfq-m1-nYB">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="SYC-dX-Tca">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                        <rect key="frame" x="20" y="18" width="353" height="47.333332061767578"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="SYC-dX-Tca" id="VAO-pj-itX">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="47.333332061767578"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DDN-R4-gD5">
+                                                    <rect key="frame" x="10" y="7.9999999999999982" width="333" height="31.333333333333329"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mfV-cv-10B">
+                                                            <rect key="frame" x="0.0" y="0.0" width="284" height="31.333333333333332"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bWV-II-Ye7">
+                                                            <rect key="frame" x="284" y="0.0" width="51" height="31.333333333333332"/>
+                                                        </switch>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="DDN-R4-gD5" firstAttribute="top" secondItem="VAO-pj-itX" secondAttribute="top" constant="8" id="5qw-1d-xpA"/>
+                                                <constraint firstAttribute="trailing" secondItem="DDN-R4-gD5" secondAttribute="trailing" constant="10" id="MuP-bf-rt4"/>
+                                                <constraint firstAttribute="bottom" secondItem="DDN-R4-gD5" secondAttribute="bottom" constant="8" id="bqQ-1k-7Tz"/>
+                                                <constraint firstItem="DDN-R4-gD5" firstAttribute="leading" secondItem="VAO-pj-itX" secondAttribute="leading" constant="10" id="ca7-zX-0QJ"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -520,17 +542,69 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <sections>
-                            <tableViewSection headerTitle="Account Info" id="fop-Yf-CMm">
+                            <tableViewSection headerTitle="Account Information" id="bCH-Qh-OPE">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="e3p-0L-PGv" rowHeight="55" style="IBUITableViewCellStyleDefault" id="KzA-Ua-n5g">
-                                        <rect key="frame" x="20" y="55.333332061767578" width="353" height="55"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="WA2-Gt-fMe" detailTextLabel="ECI-GM-Vm7" style="IBUITableViewCellStyleValue1" id="9Fq-f7-2bM">
+                                        <rect key="frame" x="20" y="55.333332061767578" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="KzA-Ua-n5g" id="3cD-eQ-DMx">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9Fq-f7-2bM" id="dho-C8-8jZ">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="e3p-0L-PGv">
-                                                    <rect key="frame" x="20" y="0.0" width="313" height="55"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="WA2-Gt-fMe">
+                                                    <rect key="frame" x="19.999999999999996" y="11.999999999999998" width="40.666666666666664" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="@gmail.com" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ECI-GM-Vm7">
+                                                    <rect key="frame" x="239.33333333333329" y="11.999999999999998" width="93.666666666666671" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="fbI-kK-yMG" detailTextLabel="VH4-Hc-pNG" style="IBUITableViewCellStyleValue1" id="BkQ-ju-iXM">
+                                        <rect key="frame" x="20" y="99" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="BkQ-ju-iXM" id="ntc-Af-oPo">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Phone Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fbI-kK-yMG">
+                                                    <rect key="frame" x="19.999999999999993" y="11.999999999999998" width="114.33333333333333" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="xxxxxxxxxx" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VH4-Hc-pNG">
+                                                    <rect key="frame" x="248" y="11.999999999999998" width="85" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Security" id="fmN-Eu-t33">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="1MA-dZ-I20" style="IBUITableViewCellStyleDefault" id="emJ-XD-cLb">
+                                        <rect key="frame" x="20" y="198.66666603088379" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="emJ-XD-cLb" id="Ql7-yA-xaz">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Change Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1MA-dZ-I20">
+                                                    <rect key="frame" x="20" y="0.0" width="313" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
@@ -539,136 +613,110 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="jBx-g1-gNU" rowHeight="55" style="IBUITableViewCellStyleDefault" id="dvM-zh-r5J">
-                                        <rect key="frame" x="20" y="110.33333206176758" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dvM-zh-r5J" id="KeN-tO-2kK">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Phone Number" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jBx-g1-gNU">
-                                                    <rect key="frame" x="20" y="0.0" width="313" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection headerTitle="Security" id="hYa-q4-Ufn">
+                            <tableViewSection id="k34-z6-eyi">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="55" id="orT-bU-ciY">
-                                        <rect key="frame" x="20" y="221.33333015441895" width="353" height="55"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="9IK-dX-azt">
+                                        <rect key="frame" x="20" y="278.33333396911621" width="353" height="45.333332061767578"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="orT-bU-ciY" id="sCS-S5-hMm">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9IK-dX-azt" id="aP7-NH-DRl">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="45.333332061767578"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="L07-LO-9Na">
-                                                    <rect key="frame" x="5" y="0.0" width="348" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Old Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L1K-bd-UQ0">
+                                                    <rect key="frame" x="20" y="9.9999999999999982" width="323" height="25.333333333333329"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="25" id="5wC-bR-vvY"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="L1K-bd-UQ0" secondAttribute="bottom" constant="10" id="88p-q6-d9i"/>
+                                                <constraint firstAttribute="trailing" secondItem="L1K-bd-UQ0" secondAttribute="trailing" constant="10" id="NDk-iH-Wuy"/>
+                                                <constraint firstItem="L1K-bd-UQ0" firstAttribute="leading" secondItem="aP7-NH-DRl" secondAttribute="leading" constant="20" id="cGP-x0-jZb"/>
+                                                <constraint firstItem="L1K-bd-UQ0" firstAttribute="top" secondItem="aP7-NH-DRl" secondAttribute="top" constant="10" id="px5-nx-k7T"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="GxP-hV-DB9">
+                                        <rect key="frame" x="20" y="323.66666603088379" width="353" height="45.333332061767578"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="GxP-hV-DB9" id="lVz-NC-g1Z">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="45.333332061767578"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="New Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Pyn-aB-Aeu">
+                                                    <rect key="frame" x="20" y="9.9999999999999982" width="323" height="25.333333333333329"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="25" id="oKH-2A-o0o"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="Pyn-aB-Aeu" secondAttribute="bottom" constant="10" id="76f-Dj-sgF"/>
+                                                <constraint firstItem="Pyn-aB-Aeu" firstAttribute="top" secondItem="lVz-NC-g1Z" secondAttribute="top" constant="10" id="Yv5-ZE-jiq"/>
+                                                <constraint firstItem="Pyn-aB-Aeu" firstAttribute="leading" secondItem="lVz-NC-g1Z" secondAttribute="leading" constant="20" id="ZSI-Ix-AHb"/>
+                                                <constraint firstAttribute="trailing" secondItem="Pyn-aB-Aeu" secondAttribute="trailing" constant="10" id="hQi-km-Drj"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="PVy-wl-6kx">
+                                        <rect key="frame" x="20" y="368.99999809265137" width="353" height="45.333332061767578"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PVy-wl-6kx" id="xrF-M8-Ljo">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="45.333332061767578"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Confirm password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="yOE-vk-GW4">
+                                                    <rect key="frame" x="20" y="9.9999999999999982" width="323" height="25.333333333333329"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="25" id="muv-EY-Oic"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <textInputTraits key="textInputTraits"/>
+                                                </textField>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="yOE-vk-GW4" firstAttribute="leading" secondItem="xrF-M8-Ljo" secondAttribute="leading" constant="20" id="P2K-7D-4Aj"/>
+                                                <constraint firstItem="yOE-vk-GW4" firstAttribute="top" secondItem="xrF-M8-Ljo" secondAttribute="top" constant="10" id="PZ1-Vw-L7N"/>
+                                                <constraint firstAttribute="bottom" secondItem="yOE-vk-GW4" secondAttribute="bottom" constant="10" id="qBV-2j-gW0"/>
+                                                <constraint firstAttribute="trailing" secondItem="yOE-vk-GW4" secondAttribute="trailing" constant="10" id="x8N-2b-GMu"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="Gk1-Ce-gBc">
+                                        <rect key="frame" x="20" y="414.33333015441895" width="353" height="45.333332061767578"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Gk1-Ce-gBc" id="EaI-eZ-sk4">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="45.333332061767578"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FuX-aE-POQ">
+                                                    <rect key="frame" x="0.0" y="0.0" width="353" height="45.333333333333336"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="45" id="IYi-rf-YmX"/>
+                                                    </constraints>
+                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <state key="normal" title="Button"/>
-                                                    <buttonConfiguration key="configuration" style="plain" title="Change Password">
+                                                    <buttonConfiguration key="configuration" style="plain" title="Change">
                                                         <fontDescription key="titleFontDescription" style="UICTFontTextStyleBody"/>
                                                     </buttonConfiguration>
-                                                </button>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="5GI-dB-v5M">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="55" id="VH6-uq-Fsc">
-                                        <rect key="frame" x="20" y="312.33333015441895" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VH6-uq-Fsc" id="nCL-ON-d50">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Old Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vVf-rb-zhJ">
-                                                    <rect key="frame" x="15" y="0.0" width="338" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
-                                                </textField>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="55" id="Bpd-IS-TjU">
-                                        <rect key="frame" x="20" y="367.33333015441895" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Bpd-IS-TjU" id="DmF-bY-iCt">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="New Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vMb-ih-w9V">
-                                                    <rect key="frame" x="15" y="0.0" width="338" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
-                                                </textField>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="55" id="Sts-Fk-R7q">
-                                        <rect key="frame" x="20" y="422.33333015441895" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Sts-Fk-R7q" id="E89-HB-8bL">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Confirm Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Q6-mC-EGt">
-                                                    <rect key="frame" x="15" y="0.0" width="338" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
-                                                </textField>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="55" id="HJ2-Wq-LRa">
-                                        <rect key="frame" x="20" y="477.33333015441895" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HJ2-Wq-LRa" id="VLP-ID-0s2">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pAj-W9-TAB">
-                                                    <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <state key="normal" title="Button"/>
-                                                    <buttonConfiguration key="configuration" style="plain" title="Change"/>
                                                     <connections>
-                                                        <action selector="changeButtonTapped:" destination="oO8-UD-jq3" eventType="touchUpInside" id="L23-iH-8cS"/>
+                                                        <action selector="changeButtonTapped:" destination="oO8-UD-jq3" eventType="touchUpInside" id="cJt-dv-aRY"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection id="5Wb-c7-ZCV">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" textLabel="9OJ-nn-Kev" rowHeight="55" style="IBUITableViewCellStyleDefault" id="Pxh-FT-zha">
-                                        <rect key="frame" x="20" y="568.33333015441895" width="353" height="55"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pxh-FT-zha" id="SK8-3b-50t">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="55"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Delete Account" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9OJ-nn-Kev">
-                                                    <rect key="frame" x="20" y="0.0" width="313" height="55"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <color key="textColor" systemColor="systemRedColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="FuX-aE-POQ" firstAttribute="leading" secondItem="EaI-eZ-sk4" secondAttribute="leading" id="9pp-K0-hYD"/>
+                                                <constraint firstItem="FuX-aE-POQ" firstAttribute="top" secondItem="EaI-eZ-sk4" secondAttribute="top" id="TBv-mc-bM5"/>
+                                                <constraint firstAttribute="bottom" secondItem="FuX-aE-POQ" secondAttribute="bottom" id="TFJ-84-y80"/>
+                                                <constraint firstAttribute="trailing" secondItem="FuX-aE-POQ" secondAttribute="trailing" id="kws-0f-iea"/>
+                                            </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
@@ -681,12 +729,12 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Account &amp; Security" id="TTY-fl-17y" customClass="Setti"/>
                     <connections>
-                        <outlet property="changePasswordButton" destination="L07-LO-9Na" id="rn1-rw-QmD"/>
-                        <outlet property="confirmPasswordField" destination="2Q6-mC-EGt" id="4eL-sY-s8c"/>
-                        <outlet property="emailLabel" destination="e3p-0L-PGv" id="Ugn-Wv-U3E"/>
-                        <outlet property="newPasswordField" destination="vMb-ih-w9V" id="svJ-Fw-d6W"/>
-                        <outlet property="oldPasswordField" destination="vVf-rb-zhJ" id="IoZ-sJ-eMv"/>
-                        <outlet property="phoneNumberLabel" destination="jBx-g1-gNU" id="eFo-ph-cTD"/>
+                        <outlet property="changePasswordButton" destination="FuX-aE-POQ" id="tlD-Da-CPv"/>
+                        <outlet property="confirmPasswordField" destination="yOE-vk-GW4" id="f1o-S9-qEv"/>
+                        <outlet property="emailLabel" destination="ECI-GM-Vm7" id="gcC-wx-3eO"/>
+                        <outlet property="newPasswordField" destination="Pyn-aB-Aeu" id="Vuv-J0-cc8"/>
+                        <outlet property="oldPasswordField" destination="L1K-bd-UQ0" id="p0D-yq-TKw"/>
+                        <outlet property="phoneNumberLabel" destination="VH4-Hc-pNG" id="98l-ju-9Iv"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DNa-Qh-vz9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -697,36 +745,93 @@
         <scene sceneID="bbJ-JP-jjR">
             <objects>
                 <tableViewController id="fdG-o2-OuS" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="quF-hh-EqY">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="quF-hh-EqY">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <sections>
                             <tableViewSection id="4y4-2f-05b">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="UxH-SB-1JA">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="GXx-g4-NbA" detailTextLabel="DFa-jV-f3o" style="IBUITableViewCellStyleValue1" id="UxH-SB-1JA">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UxH-SB-1JA" id="JbR-vl-Ajw">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="FAQ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GXx-g4-NbA">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="33" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DFa-jV-f3o">
+                                                    <rect key="frame" x="245.66666666666669" y="11.999999999999998" width="37" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="AiD-R1-fj9">
-                                        <rect key="frame" x="0.0" y="93.666667938232422" width="393" height="43.666667938232422"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" editingAccessoryType="detailDisclosureButton" textLabel="G6D-b0-zlA" detailTextLabel="dGC-qZ-aLa" style="IBUITableViewCellStyleValue1" id="AiD-R1-fj9">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AiD-R1-fj9" id="IoH-3L-CrQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Contact Support" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="G6D-b0-zlA">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="132" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Get Help" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dGC-qZ-aLa">
+                                                    <rect key="frame" x="215.66666666666669" y="11.999999999999998" width="67" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="4G0-e9-msA">
-                                        <rect key="frame" x="0.0" y="137.33333587646484" width="393" height="43.666667938232422"/>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="s5E-oz-sMZ">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="BPU-bt-Eev" detailTextLabel="kHl-v7-Fa2" style="IBUITableViewCellStyleValue1" id="NZG-gH-RhH">
+                                        <rect key="frame" x="20" y="141.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="4G0-e9-msA" id="hol-88-pla">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="NZG-gH-RhH" id="CRj-ik-v2q">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Feedback" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="BPU-bt-Eev">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="78" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Share" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="kHl-v7-Fa2">
+                                                    <rect key="frame" x="238.66666666666669" y="11.999999999999998" width="44" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -746,36 +851,115 @@
         <scene sceneID="dWw-gU-awI">
             <objects>
                 <tableViewController id="bEA-sz-osd" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="8eb-gd-KVi">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="8eb-gd-KVi">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                         <sections>
                             <tableViewSection id="baV-II-XHP">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Dcs-cn-bBO">
-                                        <rect key="frame" x="0.0" y="50" width="393" height="43.666667938232422"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="hDz-ke-Z4t" detailTextLabel="8zg-CE-fTf" style="IBUITableViewCellStyleValue1" id="Dcs-cn-bBO">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Dcs-cn-bBO" id="IYH-Nt-AxA">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="About Us" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="hDz-ke-Z4t">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="73.666666666666671" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Our Story" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8zg-CE-fTf">
+                                                    <rect key="frame" x="209.33333333333337" y="11.999999999999998" width="73.333333333333329" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="M6Z-xg-Iqf">
-                                        <rect key="frame" x="0.0" y="93.666667938232422" width="393" height="43.666667938232422"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Mn8-5G-S0Y" detailTextLabel="uvz-NN-eAF" style="IBUITableViewCellStyleValue1" id="M6Z-xg-Iqf">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="M6Z-xg-Iqf" id="w4z-g1-SdE">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="App Version" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Mn8-5G-S0Y">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="92" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="1.0.0" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uvz-NN-eAF">
+                                                    <rect key="frame" x="298" y="11.999999999999998" width="35" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="UFW-IK-HIf">
-                                        <rect key="frame" x="0.0" y="137.33333587646484" width="393" height="43.666667938232422"/>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="GvB-04-mH6">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="Kad-hr-dev" detailTextLabel="mmV-UB-cfy" style="IBUITableViewCellStyleValue1" id="JRe-yW-4tq">
+                                        <rect key="frame" x="20" y="141.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UFW-IK-HIf" id="iKd-vT-GRo">
-                                            <rect key="frame" x="0.0" y="0.0" width="393" height="43.666667938232422"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="JRe-yW-4tq" id="s78-xC-OZR">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Credits" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Kad-hr-dev">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="58" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="mmV-UB-cfy">
+                                                    <rect key="frame" x="239.00000000000003" y="11.999999999999998" width="43.666666666666664" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
                                         </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="detailDisclosureButton" indentationWidth="10" textLabel="y0T-au-34h" detailTextLabel="r3o-HH-wV4" style="IBUITableViewCellStyleValue1" id="Xwe-jl-ok6">
+                                        <rect key="frame" x="20" y="185.00000381469727" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Xwe-jl-ok6" id="7pm-YL-hKT">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open Source" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="y0T-au-34h">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="103" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Licenses" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r3o-HH-wV4">
+                                                    <rect key="frame" x="215.33333333333337" y="11.999999999999998" width="67.333333333333329" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -858,43 +1042,163 @@
                         <sections>
                             <tableViewSection id="zeF-Ra-jTD">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="7NH-Pq-she" rowHeight="50" style="IBUITableViewCellStyleDefault" id="Pos-bv-OrP">
-                                        <rect key="frame" x="20" y="25" width="353" height="50"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="ViH-ko-BjP" detailTextLabel="VfV-OR-PNH" style="IBUITableViewCellStyleValue1" id="pNB-FW-ViT">
+                                        <rect key="frame" x="20" y="25" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Pos-bv-OrP" id="2XC-hf-q6c">
-                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="50"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="pNB-FW-ViT" id="6K6-UT-2j6">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy Policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7NH-Pq-she">
-                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="50"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Privacy Policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ViH-ko-BjP">
+                                                    <rect key="frame" x="20.000000000000007" y="11.999999999999998" width="110.66666666666667" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Policy" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="VfV-OR-PNH">
+                                                    <rect key="frame" x="237.33333333333334" y="11.999999999999998" width="45.333333333333336" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="d8b-2R-gy9" detailTextLabel="B1P-Mh-A2y" style="IBUITableViewCellStyleValue1" id="PbD-qz-fel">
+                                        <rect key="frame" x="20" y="68.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PbD-qz-fel" id="hnJ-Xo-0P0">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms of Service" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d8b-2R-gy9">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="133.33333333333334" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Terms" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="B1P-Mh-A2y">
+                                                    <rect key="frame" x="235.66666666666669" y="11.999999999999998" width="47" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
-                            <tableViewSection id="s1K-Lw-Xu4">
+                            <tableViewSection id="DTw-FY-Lae">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="FFr-cP-pMh" rowHeight="50" style="IBUITableViewCellStyleDefault" id="oRi-Ee-pC7">
-                                        <rect key="frame" x="20" y="118" width="353" height="50"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="XI6-oJ-FsQ" detailTextLabel="bgg-vo-V7o" style="IBUITableViewCellStyleValue1" id="ahf-a6-svM">
+                                        <rect key="frame" x="20" y="155.33333587646484" width="353" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oRi-Ee-pC7" id="I2g-iW-Eiu">
-                                            <rect key="frame" x="0.0" y="0.0" width="322.66666666666669" height="50"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ahf-a6-svM" id="lgc-ng-Vqg">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Data Sharing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FFr-cP-pMh">
-                                                    <rect key="frame" x="20" y="0.0" width="294.66666666666669" height="50"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Code of Conduct" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XI6-oJ-FsQ">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="134.33333333333334" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="View" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bgg-vo-V7o">
+                                                    <rect key="frame" x="245.66666666666669" y="11.999999999999998" width="37" height="20.333333333333332"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <nil key="textColor"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="2XT-K9-Eox" detailTextLabel="UHa-Ou-XjL" style="IBUITableViewCellStyleValue1" id="Alu-PA-TDc">
+                                        <rect key="frame" x="20" y="199.00000381469727" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Alu-PA-TDc" id="7lj-j0-no1">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Cookie Policy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2XT-K9-Eox">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="107" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UHa-Ou-XjL">
+                                                    <rect key="frame" x="239.00000000000003" y="11.999999999999998" width="43.666666666666664" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection id="uS6-MY-nUD">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="uPb-wg-0fi" detailTextLabel="Fjh-7o-Ukc" style="IBUITableViewCellStyleValue1" id="cOc-x6-P19">
+                                        <rect key="frame" x="20" y="285.66667175292969" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cOc-x6-P19" id="7sK-BR-5mb">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Data Usage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="uPb-wg-0fi">
+                                                    <rect key="frame" x="20" y="11.999999999999998" width="92" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Learn More" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Fjh-7o-Ukc">
+                                                    <rect key="frame" x="196.33333333333337" y="11.999999999999998" width="86.333333333333329" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="detailDisclosureButton" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="bY7-1E-SD8" detailTextLabel="tCb-Lw-lt1" style="IBUITableViewCellStyleValue1" id="lum-ov-nS0">
+                                        <rect key="frame" x="20" y="329.33333969116211" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lum-ov-nS0" id="xdT-Pg-wy6">
+                                            <rect key="frame" x="0.0" y="0.0" width="290.66666666666669" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="GDPR Rights" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bY7-1E-SD8">
+                                                    <rect key="frame" x="19.999999999999993" y="11.999999999999998" width="101.33333333333333" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Your Rights" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="tCb-Lw-lt1">
+                                                    <rect key="frame" x="195.66666666666669" y="11.999999999999998" width="87" height="20.333333333333332"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <color key="textColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -1125,14 +1429,14 @@
                             <tableViewSection id="WBb-4z-ZJ4">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="PLS-ux-FKq">
-                                        <rect key="frame" x="20" y="18" width="353" height="80.333335876464844"/>
+                                        <rect key="frame" x="20" y="18" width="353" height="70.333335876464844"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PLS-ux-FKq" id="Jwi-Dj-oDa">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="80.333335876464844"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="70.333335876464844"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="e5n-kS-7Bb">
-                                                    <rect key="frame" x="0.0" y="5" width="353" height="70.333333333333329"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="353" height="70.333333333333329"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="63F-YE-pNQ">
                                                             <rect key="frame" x="141.66666666666666" y="0.6666666666666643" width="70" height="69"/>
@@ -1152,8 +1456,8 @@
                                             <constraints>
                                                 <constraint firstItem="e5n-kS-7Bb" firstAttribute="leading" secondItem="Jwi-Dj-oDa" secondAttribute="leading" id="3vT-5c-ISu"/>
                                                 <constraint firstAttribute="trailing" secondItem="e5n-kS-7Bb" secondAttribute="trailing" id="BkX-sn-tZj"/>
-                                                <constraint firstItem="e5n-kS-7Bb" firstAttribute="top" secondItem="Jwi-Dj-oDa" secondAttribute="top" constant="5" id="Jf9-dH-Qnv"/>
-                                                <constraint firstAttribute="bottom" secondItem="e5n-kS-7Bb" secondAttribute="bottom" constant="5" id="roT-B9-3dq"/>
+                                                <constraint firstItem="e5n-kS-7Bb" firstAttribute="top" secondItem="Jwi-Dj-oDa" secondAttribute="top" id="Jf9-dH-Qnv"/>
+                                                <constraint firstAttribute="bottom" secondItem="e5n-kS-7Bb" secondAttribute="bottom" id="roT-B9-3dq"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" systemColor="systemGray6Color"/>
@@ -1163,7 +1467,7 @@
                             <tableViewSection id="8Ec-Pa-bVO">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="hDA-U8-DNr">
-                                        <rect key="frame" x="20" y="134.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="124.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hDA-U8-DNr" id="VGw-yP-rFX">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1195,7 +1499,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="plg-t5-foF">
-                                        <rect key="frame" x="20" y="179.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="169.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="plg-t5-foF" id="rQB-c5-hm6">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1229,7 +1533,7 @@
                             <tableViewSection id="gvi-rS-xFL">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="EYf-Aq-XOo">
-                                        <rect key="frame" x="20" y="260.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="250.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="EYf-Aq-XOo" id="Srh-Ea-1MZ">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1267,7 +1571,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="Rxk-gV-l27">
-                                        <rect key="frame" x="20" y="305.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="295.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rxk-gV-l27" id="Pbo-SK-ULq">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1305,7 +1609,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="D0x-ae-arD">
-                                        <rect key="frame" x="20" y="350.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="340.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="D0x-ae-arD" id="5QE-OE-Tq5">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1347,7 +1651,7 @@
                             <tableViewSection id="431-tz-ZXV">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="y4a-PC-Flj">
-                                        <rect key="frame" x="20" y="431.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="421.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="y4a-PC-Flj" id="iHn-pL-ubJ">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1385,7 +1689,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="ZIH-NI-Ztt">
-                                        <rect key="frame" x="20" y="476.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="466.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZIH-NI-Ztt" id="LoP-3r-VMB">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1423,7 +1727,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="ProfileInfoCell" rowHeight="45" id="RDt-8F-sPi">
-                                        <rect key="frame" x="20" y="521.33333587646484" width="353" height="45"/>
+                                        <rect key="frame" x="20" y="511.33333587646484" width="353" height="45"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RDt-8F-sPi" id="mlM-Ao-O5M">
                                             <rect key="frame" x="0.0" y="0.0" width="353" height="45"/>
@@ -1566,10 +1870,10 @@
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGray6Color">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
             <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">

--- a/MomCare/StoryBoards/Dashboard/Nib/EventCard.xib
+++ b/MomCare/StoryBoards/Dashboard/Nib/EventCard.xib
@@ -3,7 +3,6 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -45,20 +44,20 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="iqi-IQ-Xu6">
-                                <rect key="frame" x="3" y="8" width="151.66666666666666" height="34.333333333333336"/>
+                                <rect key="frame" x="15" y="8" width="157" height="34.333333333333336"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6rn-Tc-0Bn">
-                                        <rect key="frame" x="0.0" y="0.0" width="151.66666666666666" height="34.333333333333336"/>
-                                        <color key="tintColor" systemColor="linkColor"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="157" height="34.333333333333336"/>
+                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="Button"/>
-                                        <buttonConfiguration key="configuration" style="plain" title="Add Event" titleAlignment="leading"/>
+                                        <buttonConfiguration key="configuration" style="plain" image="plus" catalog="system" title="Add Event" titleAlignment="leading"/>
                                         <connections>
                                             <action selector="addEventButtonTapped:" destination="t1y-Ib-jg4" eventType="touchUpInside" id="UJE-8S-e4Z"/>
                                         </connections>
                                     </button>
                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Upcoming Event" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qRi-OX-TIw">
-                                        <rect key="frame" x="0.0" y="0.0" width="151.66666666666666" height="0.0"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="157" height="0.0"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
@@ -71,7 +70,7 @@
                             <constraint firstItem="iqi-IQ-Xu6" firstAttribute="centerY" secondItem="iyF-9F-32h" secondAttribute="centerY" id="E09-bP-5x3"/>
                             <constraint firstAttribute="trailing" secondItem="qBD-uw-ovo" secondAttribute="trailing" constant="10" id="Sq9-Ef-KuI"/>
                             <constraint firstAttribute="bottom" secondItem="qBD-uw-ovo" secondAttribute="bottom" constant="30" id="aOY-tJ-kCg"/>
-                            <constraint firstItem="iqi-IQ-Xu6" firstAttribute="leading" secondItem="iyF-9F-32h" secondAttribute="leading" constant="3" id="hle-vq-bML"/>
+                            <constraint firstItem="iqi-IQ-Xu6" firstAttribute="leading" secondItem="iyF-9F-32h" secondAttribute="leading" constant="15" id="hle-vq-bML"/>
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="B7y-Xb-hxj">
@@ -116,9 +115,7 @@
     </objects>
     <resources>
         <image name="calendar.badge.clock" catalog="system" width="128" height="109"/>
-        <systemColor name="linkColor">
-            <color red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
+        <image name="plus" catalog="system" width="128" height="113"/>
         <systemColor name="tableCellGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/MomCare/StoryBoards/Dashboard/Nib/EventCard.xib
+++ b/MomCare/StoryBoards/Dashboard/Nib/EventCard.xib
@@ -45,7 +45,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="iqi-IQ-Xu6">
-                                <rect key="frame" x="10" y="8" width="151.66666666666666" height="34.333333333333336"/>
+                                <rect key="frame" x="3" y="8" width="151.66666666666666" height="34.333333333333336"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6rn-Tc-0Bn">
                                         <rect key="frame" x="0.0" y="0.0" width="151.66666666666666" height="34.333333333333336"/>
@@ -71,7 +71,7 @@
                             <constraint firstItem="iqi-IQ-Xu6" firstAttribute="centerY" secondItem="iyF-9F-32h" secondAttribute="centerY" id="E09-bP-5x3"/>
                             <constraint firstAttribute="trailing" secondItem="qBD-uw-ovo" secondAttribute="trailing" constant="10" id="Sq9-Ef-KuI"/>
                             <constraint firstAttribute="bottom" secondItem="qBD-uw-ovo" secondAttribute="bottom" constant="30" id="aOY-tJ-kCg"/>
-                            <constraint firstItem="iqi-IQ-Xu6" firstAttribute="leading" secondItem="iyF-9F-32h" secondAttribute="leading" constant="10" id="hle-vq-bML"/>
+                            <constraint firstItem="iqi-IQ-Xu6" firstAttribute="leading" secondItem="iyF-9F-32h" secondAttribute="leading" constant="3" id="hle-vq-bML"/>
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="B7y-Xb-hxj">

--- a/MomCare/StoryBoards/Dashboard/Nib/FocusCard.xib
+++ b/MomCare/StoryBoards/Dashboard/Nib/FocusCard.xib
@@ -64,7 +64,7 @@
                         <string key="text">Did you know? 
 Staying active during pregnancy helps reduce discomfort</string>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                        <nil key="textColor"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>

--- a/MomCare/StoryBoards/Dashboard/Nib/TipCard.xib
+++ b/MomCare/StoryBoards/Dashboard/Nib/TipCard.xib
@@ -64,7 +64,7 @@
                         <string key="text">Did you know? 
 Staying active during pregnancy helps reduce discomfort</string>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                        <nil key="textColor"/>
+                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>

--- a/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
@@ -61,14 +61,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="kWs-V6-I3w">
-                                        <rect key="frame" x="20" y="275" width="353" height="217"/>
+                                        <rect key="frame" x="20" y="275" width="353" height="221"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kWs-V6-I3w" id="Edk-jC-c0p">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="217"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="221"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mqZ-AD-J1M">
-                                                    <rect key="frame" x="0.0" y="20" width="353" height="177"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="mqZ-AD-J1M">
+                                                    <rect key="frame" x="0.0" y="20" width="353" height="181"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Data, Your Rights, Your Trust" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Say-2C-Wwy">
                                                             <rect key="frame" x="0.0" y="0.0" width="353" height="20.333333333333332"/>
@@ -77,26 +77,26 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ry6-Tf-eEz">
-                                                            <rect key="frame" x="0.0" y="30.333333333333343" width="353" height="78"/>
+                                                            <rect key="frame" x="0.0" y="31.333333333333343" width="353" height="78"/>
                                                             <string key="text">Welcome to Momcare+, your personalized pregnancy care companion. We are committed to safeguarding your privacy and protecting any information you share with us.</string>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This Privacy Policy describes:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-MS-kmj">
-                                                            <rect key="frame" x="0.0" y="118.33333333333333" width="353" height="20.333333333333329"/>
+                                                            <rect key="frame" x="0.0" y="120.66666666666664" width="353" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mB5-Bb-St5">
-                                                            <rect key="frame" x="0.0" y="148.66666666666666" width="353" height="0.0"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mB5-Bb-St5">
+                                                            <rect key="frame" x="0.0" y="152" width="353" height="0.0"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Please read it carefully before using the app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HL5-oa-cj3">
-                                                            <rect key="frame" x="0.0" y="158.66666666666666" width="353" height="18.333333333333343"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Please read it carefully before using the app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HL5-oa-cj3">
+                                                            <rect key="frame" x="0.0" y="163" width="353" height="18"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -112,6 +112,146 @@
                                                 <constraint firstItem="mqZ-AD-J1M" firstAttribute="leading" secondItem="Edk-jC-c0p" secondAttribute="leading" id="sI2-ul-isk"/>
                                                 <constraint firstItem="mqZ-AD-J1M" firstAttribute="top" secondItem="Edk-jC-c0p" secondAttribute="top" constant="20" id="see-qz-MF2"/>
                                                 <constraint firstAttribute="bottom" secondItem="mqZ-AD-J1M" secondAttribute="bottom" constant="20" id="xVq-tG-bff"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="1x3-FP-wMw">
+                                        <rect key="frame" x="20" y="496" width="353" height="359.33334350585938"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1x3-FP-wMw" id="hG1-gA-Dql">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="359.33334350585938"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="87N-gM-el0">
+                                                    <rect key="frame" x="0.0" y="20" width="353" height="319.33333333333331"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HOW MOMCARE+ WORKS" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H7a-Is-03x">
+                                                            <rect key="frame" x="0.0" y="0.0" width="353" height="14.333333333333334"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                            <color key="textColor" systemColor="secondaryLabelColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Momcare+ is designed to support expecting mothers through:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AlN-84-QlR">
+                                                            <rect key="frame" x="0.0" y="25.333333333333336" width="353" height="38"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This Privacy Policy describes:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Akb-S0-r9M">
+                                                            <rect key="frame" x="0.0" y="74.333333333333329" width="353" height="20.333333333333329"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="Q4t-1t-b83">
+                                                            <rect key="frame" x="0.0" y="105.66666666666667" width="353" height="38.000000000000014"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4yV-Qj-k2Q">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="57" height="37.666666666666671"/>
+                                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" secondItem="4yV-Qj-k2Q" secondAttribute="height" multiplier="100:70" id="oeM-cs-F7r"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Personalized weekly guidance based on your trimester" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTG-O3-EQo">
+                                                                    <rect key="frame" x="76.333333333333343" y="0.0" width="276.66666666666663" height="38"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Rl5-dF-lGQ">
+                                                            <rect key="frame" x="0.0" y="155" width="353" height="30.333333333333343"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="PHd-oM-qlM">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="43.333333333333336" height="27.333333333333336"/>
+                                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" secondItem="PHd-oM-qlM" secondAttribute="height" multiplier="100:70" id="3Zd-xQ-N7P"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKG-G2-Qlm">
+                                                                    <rect key="frame" x="43.333333333333343" y="0.0" width="309.66666666666663" height="30.333333333333332"/>
+                                                                    <string key="text">Daily wellness tracking for mood, symptoms, exercise, and diet
+
+</string>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="E9o-Zu-owb">
+                                                            <rect key="frame" x="0.0" y="196.33333333333334" width="353" height="51.333333333333343"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="bell.badge" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="WEo-xm-lqH">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="73.333333333333329" height="48.333333333333336"/>
+                                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" secondItem="WEo-xm-lqH" secondAttribute="height" multiplier="100:70" id="qTT-pP-hQ4"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfC-Vh-nde">
+                                                                    <rect key="frame" x="73.333333333333343" y="0.0" width="279.66666666666663" height="51.333333333333336"/>
+                                                                    <string key="text">Reminders for medical checkups, scans, supplements, and hydration
+
+</string>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Oe-tf-wjn">
+                                                            <rect key="frame" x="0.0" y="258.66666666666669" width="353" height="26.666666666666686"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="yOG-rj-uEN">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="38" height="23.666666666666671"/>
+                                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" secondItem="yOG-rj-uEN" secondAttribute="height" multiplier="100:70" id="noh-0G-O0F"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SPp-cE-yl4">
+                                                                    <rect key="frame" x="38" y="0.0" width="315" height="26.666666666666668"/>
+                                                                    <string key="text">Mental wellness tools like breathing exercises and calming activities
+
+</string>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4i2-ge-3Xp">
+                                                            <rect key="frame" x="0.0" y="296.33333333333331" width="353" height="23"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="fT7-Ng-gc9">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="35.666666666666671" height="22.666666666666668"/>
+                                                                    <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" secondItem="fT7-Ng-gc9" secondAttribute="height" multiplier="100:70" id="2B8-yT-sbg"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="TrimesterTrack and ProgressHub, which adapt tips based on your health trends and habits" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jul-mV-gaJ">
+                                                                    <rect key="frame" x="33" y="0.0" width="320" height="23"/>
+                                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                    <nil key="textColor"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                        </stackView>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="87N-gM-el0" firstAttribute="centerX" secondItem="hG1-gA-Dql" secondAttribute="centerX" id="0MH-re-jZo"/>
+                                                <constraint firstItem="87N-gM-el0" firstAttribute="centerY" secondItem="hG1-gA-Dql" secondAttribute="centerY" id="IAJ-GI-ew9"/>
+                                                <constraint firstItem="87N-gM-el0" firstAttribute="leading" secondItem="hG1-gA-Dql" secondAttribute="leading" id="R0W-Kz-fZ8"/>
+                                                <constraint firstAttribute="bottom" secondItem="87N-gM-el0" secondAttribute="bottom" constant="20" id="bqb-lP-b3q"/>
+                                                <constraint firstItem="87N-gM-el0" firstAttribute="top" secondItem="hG1-gA-Dql" secondAttribute="top" constant="20" id="rXF-Tw-FCJ"/>
+                                                <constraint firstAttribute="trailing" secondItem="87N-gM-el0" secondAttribute="trailing" id="y5J-zC-0yv"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -378,7 +518,13 @@
         </scene>
     </scenes>
     <resources>
+        <image name="bell.badge" catalog="system" width="117" height="128"/>
+        <image name="calendar.badge.clock" catalog="system" width="128" height="109"/>
+        <image name="heart.square" catalog="system" width="128" height="114"/>
         <image name="lock.shield" catalog="system" width="121" height="128"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
@@ -116,14 +116,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="1x3-FP-wMw">
-                                        <rect key="frame" x="20" y="496" width="353" height="359.33334350585938"/>
+                                        <rect key="frame" x="20" y="496" width="353" height="411"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1x3-FP-wMw" id="hG1-gA-Dql">
-                                            <rect key="frame" x="0.0" y="0.0" width="353" height="359.33334350585938"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="411"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="87N-gM-el0">
-                                                    <rect key="frame" x="0.0" y="20" width="353" height="319.33333333333331"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="87N-gM-el0">
+                                                    <rect key="frame" x="0.0" y="20" width="353" height="371"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="HOW MOMCARE+ WORKS" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H7a-Is-03x">
                                                             <rect key="frame" x="0.0" y="0.0" width="353" height="14.333333333333334"/>
@@ -132,47 +132,53 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Momcare+ is designed to support expecting mothers through:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AlN-84-QlR">
-                                                            <rect key="frame" x="0.0" y="25.333333333333336" width="353" height="38"/>
+                                                            <rect key="frame" x="0.0" y="28.333333333333336" width="353" height="38.000000000000007"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This Privacy Policy describes:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Akb-S0-r9M">
-                                                            <rect key="frame" x="0.0" y="74.333333333333329" width="353" height="20.333333333333329"/>
+                                                            <rect key="frame" x="0.0" y="80.333333333333329" width="353" height="20.333333333333329"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="equalCentering" translatesAutoresizingMaskIntoConstraints="NO" id="Q4t-1t-b83">
-                                                            <rect key="frame" x="0.0" y="105.66666666666667" width="353" height="38.000000000000014"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Q4t-1t-b83">
+                                                            <rect key="frame" x="0.0" y="114.66666666666666" width="353" height="40"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4yV-Qj-k2Q">
-                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="57" height="37.666666666666671"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="4yV-Qj-k2Q">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="42.666666666666671" height="39.666666666666671"/>
                                                                     <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="4yV-Qj-k2Q" secondAttribute="height" multiplier="100:70" id="oeM-cs-F7r"/>
+                                                                        <constraint firstAttribute="width" secondItem="4yV-Qj-k2Q" secondAttribute="height" multiplier="1:1" id="oeM-cs-F7r"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Personalized weekly guidance based on your trimester" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTG-O3-EQo">
-                                                                    <rect key="frame" x="76.333333333333343" y="0.0" width="276.66666666666663" height="38"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Personalized weekly guidance based on your trimester" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zTG-O3-EQo">
+                                                                    <rect key="frame" x="45" y="0.0" width="308" height="40"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="40" id="bhF-Wy-1Eb"/>
+                                                                    </constraints>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Rl5-dF-lGQ">
-                                                            <rect key="frame" x="0.0" y="155" width="353" height="30.333333333333343"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Rl5-dF-lGQ">
+                                                            <rect key="frame" x="0.0" y="169" width="353" height="40"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="PHd-oM-qlM">
-                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="43.333333333333336" height="27.333333333333336"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="PHd-oM-qlM">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="40" height="37"/>
                                                                     <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="PHd-oM-qlM" secondAttribute="height" multiplier="100:70" id="3Zd-xQ-N7P"/>
+                                                                        <constraint firstAttribute="width" secondItem="PHd-oM-qlM" secondAttribute="height" multiplier="1:1" id="3Zd-xQ-N7P"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKG-G2-Qlm">
-                                                                    <rect key="frame" x="43.333333333333343" y="0.0" width="309.66666666666663" height="30.333333333333332"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YKG-G2-Qlm">
+                                                                    <rect key="frame" x="45" y="0.0" width="308" height="40"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="40" id="cS1-zZ-mZ1"/>
+                                                                    </constraints>
                                                                     <string key="text">Daily wellness tracking for mood, symptoms, exercise, and diet
 
 </string>
@@ -182,18 +188,21 @@
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="E9o-Zu-owb">
-                                                            <rect key="frame" x="0.0" y="196.33333333333334" width="353" height="51.333333333333343"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="E9o-Zu-owb">
+                                                            <rect key="frame" x="0.0" y="223" width="353" height="40"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="bell.badge" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="WEo-xm-lqH">
-                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="73.333333333333329" height="48.333333333333336"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" image="bell.badge" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="WEo-xm-lqH">
+                                                                    <rect key="frame" x="0.0" y="-0.66666666666666785" width="40" height="40.333333333333343"/>
                                                                     <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="WEo-xm-lqH" secondAttribute="height" multiplier="100:70" id="qTT-pP-hQ4"/>
+                                                                        <constraint firstAttribute="width" secondItem="WEo-xm-lqH" secondAttribute="height" multiplier="1:1" id="qTT-pP-hQ4"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfC-Vh-nde">
-                                                                    <rect key="frame" x="73.333333333333343" y="0.0" width="279.66666666666663" height="51.333333333333336"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cfC-Vh-nde">
+                                                                    <rect key="frame" x="45" y="0.0" width="308" height="40"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="40" id="HXU-KW-unC"/>
+                                                                    </constraints>
                                                                     <string key="text">Reminders for medical checkups, scans, supplements, and hydration
 
 </string>
@@ -203,18 +212,21 @@
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9Oe-tf-wjn">
-                                                            <rect key="frame" x="0.0" y="258.66666666666669" width="353" height="26.666666666666686"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="9Oe-tf-wjn">
+                                                            <rect key="frame" x="0.0" y="277" width="353" height="40"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="yOG-rj-uEN">
-                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="38" height="23.666666666666671"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" image="heart.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="yOG-rj-uEN">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="40" height="37"/>
                                                                     <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="yOG-rj-uEN" secondAttribute="height" multiplier="100:70" id="noh-0G-O0F"/>
+                                                                        <constraint firstAttribute="width" secondItem="yOG-rj-uEN" secondAttribute="height" multiplier="1:1" id="noh-0G-O0F"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SPp-cE-yl4">
-                                                                    <rect key="frame" x="38" y="0.0" width="315" height="26.666666666666668"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SPp-cE-yl4">
+                                                                    <rect key="frame" x="45" y="0.0" width="308" height="40"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="40" id="emv-4W-dB5"/>
+                                                                    </constraints>
                                                                     <string key="text">Mental wellness tools like breathing exercises and calming activities
 
 </string>
@@ -224,18 +236,21 @@
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4i2-ge-3Xp">
-                                                            <rect key="frame" x="0.0" y="296.33333333333331" width="353" height="23"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="4i2-ge-3Xp">
+                                                            <rect key="frame" x="0.0" y="331" width="353" height="40"/>
                                                             <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" ambiguous="YES" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="fT7-Ng-gc9">
-                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="35.666666666666671" height="22.666666666666668"/>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="251" image="calendar.badge.clock" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="fT7-Ng-gc9">
+                                                                    <rect key="frame" x="0.0" y="1.6666666666666643" width="42.666666666666671" height="39.666666666666671"/>
                                                                     <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" secondItem="fT7-Ng-gc9" secondAttribute="height" multiplier="100:70" id="2B8-yT-sbg"/>
+                                                                        <constraint firstAttribute="width" secondItem="fT7-Ng-gc9" secondAttribute="height" multiplier="1:1" id="2B8-yT-sbg"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="TrimesterTrack and ProgressHub, which adapt tips based on your health trends and habits" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jul-mV-gaJ">
-                                                                    <rect key="frame" x="33" y="0.0" width="320" height="23"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TrimesterTrack and ProgressHub, which adapt tips based on your health trends and habits" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jul-mV-gaJ">
+                                                                    <rect key="frame" x="45" y="0.0" width="308" height="40"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="40" id="aYd-7Y-mgY"/>
+                                                                    </constraints>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>

--- a/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
+++ b/MomCare/StoryBoards/Dashboard/ProfileCellStoryboards/LegalComplianceStoryboard.storyboard
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Privacy Policy Table View Controller-->
+        <scene sceneID="A13-UF-L4E">
+            <objects>
+                <tableViewController storyboardIdentifier="PrivacyPolicyTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="gv2-EM-Jlp" customClass="PrivacyPolicyTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="FRW-iI-8eK">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="separatorColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <inset key="separatorInset" minX="5" minY="0.0" maxX="5" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="qTO-6d-kb9">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="VYr-Ex-eS1">
+                                        <rect key="frame" x="20" y="18" width="353" height="257"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VYr-Ex-eS1" id="khn-90-2bL">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="257"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="uXE-T6-f67">
+                                                    <rect key="frame" x="0.0" y="20" width="353" height="217"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="lock.shield" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="pLi-Z0-4qW">
+                                                            <rect key="frame" x="0.0" y="1" width="353" height="58.666666666666671"/>
+                                                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="60" id="3ho-tg-5s4"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Because Every Mom Deserves Care Including for Her Data" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AvJ-Bo-rtJ">
+                                                            <rect key="frame" x="0.0" y="67.333333333333343" width="353" height="100.33333333333334"/>
+                                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="28"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Learn how we respect and protect your privacy at Momcare+" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sca-MG-RvD">
+                                                            <rect key="frame" x="0.0" y="174.66666666666666" width="353" height="42.333333333333343"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="uXE-T6-f67" secondAttribute="trailing" id="5vf-fy-pYH"/>
+                                                <constraint firstItem="uXE-T6-f67" firstAttribute="leading" secondItem="khn-90-2bL" secondAttribute="leading" id="Ftc-fR-79z"/>
+                                                <constraint firstAttribute="bottom" secondItem="uXE-T6-f67" secondAttribute="bottom" constant="20" id="sEc-NC-Ejm"/>
+                                                <constraint firstItem="uXE-T6-f67" firstAttribute="top" secondItem="khn-90-2bL" secondAttribute="top" constant="20" id="wh2-tj-cYo"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="kWs-V6-I3w">
+                                        <rect key="frame" x="20" y="275" width="353" height="217"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kWs-V6-I3w" id="Edk-jC-c0p">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="217"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mqZ-AD-J1M">
+                                                    <rect key="frame" x="0.0" y="20" width="353" height="177"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your Data, Your Rights, Your Trust" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Say-2C-Wwy">
+                                                            <rect key="frame" x="0.0" y="0.0" width="353" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ry6-Tf-eEz">
+                                                            <rect key="frame" x="0.0" y="30.333333333333343" width="353" height="78"/>
+                                                            <string key="text">Welcome to Momcare+, your personalized pregnancy care companion. We are committed to safeguarding your privacy and protecting any information you share with us.</string>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This Privacy Policy describes:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eG8-MS-kmj">
+                                                            <rect key="frame" x="0.0" y="118.33333333333333" width="353" height="20.333333333333329"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mB5-Bb-St5">
+                                                            <rect key="frame" x="0.0" y="148.66666666666666" width="353" height="0.0"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Please read it carefully before using the app." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HL5-oa-cj3">
+                                                            <rect key="frame" x="0.0" y="158.66666666666666" width="353" height="18.333333333333343"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="mB5-Bb-St5" firstAttribute="top" secondItem="eG8-MS-kmj" secondAttribute="bottom" constant="10.000000000000028" id="wfT-dQ-Ejb"/>
+                                                    </constraints>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="mqZ-AD-J1M" secondAttribute="trailing" id="lTN-Gm-BdM"/>
+                                                <constraint firstItem="mqZ-AD-J1M" firstAttribute="leading" secondItem="Edk-jC-c0p" secondAttribute="leading" id="sI2-ul-isk"/>
+                                                <constraint firstItem="mqZ-AD-J1M" firstAttribute="top" secondItem="Edk-jC-c0p" secondAttribute="top" constant="20" id="see-qz-MF2"/>
+                                                <constraint firstAttribute="bottom" secondItem="mqZ-AD-J1M" secondAttribute="bottom" constant="20" id="xVq-tG-bff"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="gv2-EM-Jlp" id="Dib-LM-93g"/>
+                            <outlet property="delegate" destination="gv2-EM-Jlp" id="0vB-kz-Syh"/>
+                        </connections>
+                    </tableView>
+                    <connections>
+                        <outlet property="privacyPoliceDescription" destination="mB5-Bb-St5" id="83Y-yM-hKk"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Tz4-F8-FzD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="891" y="-27"/>
+        </scene>
+        <!--Terms Of Service Table View Controller-->
+        <scene sceneID="5Og-14-WKM">
+            <objects>
+                <tableViewController storyboardIdentifier="TermsOfServiceTableViewController" id="FcZ-97-4qw" customClass="TermsOfServiceTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="f40-oC-job">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="t9k-dX-c2v">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="rP9-r6-AFA">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rP9-r6-AFA" id="cQN-9F-pti">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="XeT-8E-1bE">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XeT-8E-1bE" id="q6b-bj-qCN">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="cna-pc-BON">
+                                        <rect key="frame" x="20" y="105.33333587646484" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cna-pc-BON" id="WNA-qN-Ufo">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="FcZ-97-4qw" id="MpC-MV-CE8"/>
+                            <outlet property="delegate" destination="FcZ-97-4qw" id="XgX-CC-EXC"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="raJ-mj-2jn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1624" y="-27"/>
+        </scene>
+        <!--Code Of Conduct Table View Controller-->
+        <scene sceneID="bkw-lS-dsz">
+            <objects>
+                <tableViewController storyboardIdentifier="CodeOfConductTableViewController" id="Cf6-AL-ScY" customClass="CodeOfConductTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="v08-5l-vXh">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="J8d-qz-cBa">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="cXV-LM-TQg">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cXV-LM-TQg" id="aXR-rA-Rc5">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="dxH-6T-45G">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dxH-6T-45G" id="o2a-lV-Pl3">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="RFK-GF-4mH">
+                                        <rect key="frame" x="20" y="105.33333587646484" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="RFK-GF-4mH" id="Yve-9Q-ahC">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Cf6-AL-ScY" id="2uA-op-QRO"/>
+                            <outlet property="delegate" destination="Cf6-AL-ScY" id="mFJ-Ct-sLp"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x9j-ST-YRa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2337" y="-27"/>
+        </scene>
+        <!--Cookie Policy Table View Controller-->
+        <scene sceneID="edc-T8-Y50">
+            <objects>
+                <tableViewController storyboardIdentifier="CookiePolicyTableViewController" id="Zp7-BQ-P8b" customClass="CookiePolicyTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="r2c-Pe-Wse">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="bwE-sT-MdY">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Vwt-j2-OBk">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Vwt-j2-OBk" id="Fg9-jB-lfS">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="bBe-G2-4q3">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bBe-G2-4q3" id="Dzk-HA-Hrc">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Z4b-P5-Ex0">
+                                        <rect key="frame" x="20" y="105.33333587646484" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Z4b-P5-Ex0" id="rAZ-Y5-38k">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Zp7-BQ-P8b" id="2T1-pO-lhu"/>
+                            <outlet property="delegate" destination="Zp7-BQ-P8b" id="l4A-jm-rPv"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pnQ-5F-bZF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="891" y="665"/>
+        </scene>
+        <!--Data Usage Table View Controller-->
+        <scene sceneID="DTc-Ui-dKh">
+            <objects>
+                <tableViewController storyboardIdentifier="DataUsageTableViewController" id="26S-52-B7M" customClass="DataUsageTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="zTc-NJ-zwL">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="qg2-hZ-wPe">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Bsl-np-oaN">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Bsl-np-oaN" id="JJM-KH-thJ">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="jUP-lh-ZEX">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jUP-lh-ZEX" id="WL6-qX-bXB">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Kpt-1d-i7h">
+                                        <rect key="frame" x="20" y="105.33333587646484" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Kpt-1d-i7h" id="U1t-lY-2q9">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="26S-52-B7M" id="grq-ud-U6e"/>
+                            <outlet property="delegate" destination="26S-52-B7M" id="kYb-XI-UsL"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Gsv-su-F9B" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1624" y="665"/>
+        </scene>
+        <!--Global Rights Table View Controller-->
+        <scene sceneID="666-Qh-jiP">
+            <objects>
+                <tableViewController storyboardIdentifier="GlobalRightsTableViewController" id="Hel-n8-dJn" customClass="GlobalRightsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="E3S-on-wvY">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <inset key="separatorInset" minX="8" minY="0.0" maxX="8" maxY="0.0"/>
+                        <sections>
+                            <tableViewSection id="LCb-bq-1WV">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="04d-L6-vxN">
+                                        <rect key="frame" x="20" y="18" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="04d-L6-vxN" id="GQZ-aM-fV7">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="oX6-kq-YNP">
+                                        <rect key="frame" x="20" y="61.666667938232422" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oX6-kq-YNP" id="s8h-78-I3O">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="dtN-xY-Exx">
+                                        <rect key="frame" x="20" y="105.33333587646484" width="353" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dtN-xY-Exx" id="ti5-j9-AJM">
+                                            <rect key="frame" x="0.0" y="0.0" width="353" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="Hel-n8-dJn" id="zoG-a5-G27"/>
+                            <outlet property="delegate" destination="Hel-n8-dJn" id="ZqL-RT-HQZ"/>
+                        </connections>
+                    </tableView>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="blm-Cv-HqO" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2337" y="665"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="lock.shield" catalog="system" width="121" height="128"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/MomCare/StoryBoards/MyPlan/BreathingPlayer.storyboard
+++ b/MomCare/StoryBoards/MyPlan/BreathingPlayer.storyboard
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,84 +15,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="BMB-5d-LyF">
-                                <rect key="frame" x="49" y="106.66666666666669" width="295" height="639"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="uvf-sw-9WF">
-                                        <rect key="frame" x="0.0" y="0.0" width="295" height="69"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ready" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wNx-Tz-cDC">
-                                                <rect key="frame" x="101.33333333333334" y="0.0" width="92.333333333333343" height="40.666666666666664"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3O5-oH-bYG">
-                                                <rect key="frame" x="140" y="48.666666666666671" width="15.333333333333343" height="20.333333333333329"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3TB-19-Wyg">
-                                        <rect key="frame" x="0.0" y="173.66666666666666" width="295" height="294.66666666666674"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="3TB-19-Wyg" secondAttribute="height" id="wPp-El-cNy"/>
-                                        </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="vA5-b1-7Pr">
-                                        <rect key="frame" x="0.0" y="576.33333333333337" width="295" height="62.666666666666629"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--:--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6AY-v3-TEe">
-                                                <rect key="frame" x="0.0" y="0.0" width="295" height="20.333333333333332"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="PD5-x9-DIR">
-                                                <rect key="frame" x="0.0" y="28.333333333333375" width="295" height="34.333333333333343"/>
-                                                <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KuG-t0-T09">
-                                                        <rect key="frame" x="0.0" y="0.0" width="143.66666666666666" height="34.333333333333336"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="filled" title="Start" cornerStyle="capsule" buttonSize="medium"/>
-                                                        <connections>
-                                                            <action selector="startPauseButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="Wht-PF-4Go"/>
-                                                        </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eRV-zi-M11">
-                                                        <rect key="frame" x="151.66666666666663" y="0.0" width="143.33333333333337" height="34.333333333333336"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="filled" title="Stop" cornerStyle="capsule"/>
-                                                        <connections>
-                                                            <action selector="stopButtonTapped:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="1kN-Ze-DSI"/>
-                                                        </connections>
-                                                    </button>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--:--" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6AY-v3-TEe">
+                                <rect key="frame" x="165" y="577" width="63.333333333333343" height="37"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="31"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="BMB-5d-LyF" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="a7K-04-pPP"/>
-                            <constraint firstItem="BMB-5d-LyF" firstAttribute="height" secondItem="5EZ-qb-Rvc" secondAttribute="height" multiplier="0.75" id="j4d-Wm-81X"/>
-                            <constraint firstItem="BMB-5d-LyF" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" id="kcX-ol-l3p"/>
-                            <constraint firstItem="BMB-5d-LyF" firstAttribute="width" secondItem="5EZ-qb-Rvc" secondAttribute="width" multiplier="0.75" id="lYU-YC-NoW"/>
+                            <constraint firstItem="6AY-v3-TEe" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="0FD-8T-FfR"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="6AY-v3-TEe" secondAttribute="bottom" constant="170" id="tlh-vN-Ybd"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="OA4-U9-qSa"/>
                     <connections>
-                        <outlet property="animationView" destination="3TB-19-Wyg" id="kdb-aK-184"/>
-                        <outlet property="instructionLabel" destination="wNx-Tz-cDC" id="LIq-Qh-WV4"/>
-                        <outlet property="instructionTimerLabel" destination="3O5-oH-bYG" id="rBM-n3-KbO"/>
-                        <outlet property="overallTimerLabel" destination="6AY-v3-TEe" id="MlJ-0t-D3x"/>
-                        <outlet property="startPauseButton" destination="KuG-t0-T09" id="8pI-T6-X8m"/>
-                        <outlet property="stopButton" destination="eRV-zi-M11" id="cOw-6h-28Q"/>
+                        <outlet property="totalBreatingDuration" destination="6AY-v3-TEe" id="hFH-dL-mWp"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseDateCell.xib
+++ b/MomCare/StoryBoards/MyPlan/Nib/Exercise/ExerciseDateCell.xib
@@ -11,20 +11,20 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFill" id="WZf-zl-hy4" customClass="ExerciseDateCellCollectionViewCell" customModule="MomCare" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="370" height="103"/>
+            <rect key="frame" x="0.0" y="0.0" width="438" height="147"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yq1-ed-KzG">
-                <rect key="frame" x="0.0" y="0.0" width="370" height="103"/>
+                <rect key="frame" x="0.0" y="0.0" width="438" height="147"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="4ax-XF-OSs">
-                        <rect key="frame" x="30" y="10" width="310" height="83"/>
+                        <rect key="frame" x="30" y="10" width="378" height="127"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="zoF-xn-Mtm">
-                                <rect key="frame" x="0.0" y="0.0" width="310" height="77.666666666666671"/>
+                                <rect key="frame" x="0.0" y="0.0" width="378" height="108"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="miF-Xy-KkQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iB0-A4-Y02">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -33,12 +33,12 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ftP-Qq-Hsq">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="EeX-EV-uED">
-                                        <rect key="frame" x="50" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="54.666666666666671" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="M" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CvL-Gh-4yM">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -47,13 +47,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Vl-ul-h0d">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="OUo-LS-QAH">
-                                        <rect key="frame" x="100" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="109.33333333333334" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="T" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5EF-bc-Rf7">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -62,13 +62,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="beu-mT-CwD">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="RRQ-WA-vbq">
-                                        <rect key="frame" x="150" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="164" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="W" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T8W-CK-yo9">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -77,13 +77,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E8f-Qt-p0J">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="xVj-s2-9bI">
-                                        <rect key="frame" x="200" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="218.66666666666666" y="0.0" width="49.999999999999972" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="T" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TLd-h9-wz2">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -92,13 +92,13 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TS3-la-B5a">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="hT3-hN-BdS">
-                                        <rect key="frame" x="250" y="0.0" width="50" height="77.666666666666671"/>
+                                        <rect key="frame" x="273.33333333333331" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="F" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SZu-Hg-Fk4">
                                                 <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
@@ -107,22 +107,22 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wDf-27-3AR">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="50" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="c52-OA-Zep">
-                                        <rect key="frame" x="300" y="0.0" width="10" height="77.666666666666671"/>
+                                        <rect key="frame" x="328" y="0.0" width="50" height="108"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="S" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FmW-Cs-MH9">
-                                                <rect key="frame" x="0.0" y="0.0" width="10" height="15.333333333333334"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="50" height="15.333333333333334"/>
                                                 <fontDescription key="fontDescription" name="HelveticaNeue" family="Helvetica Neue" pointSize="13"/>
                                                 <color key="textColor" red="0.57254904510000004" green="0.26274511220000002" blue="0.31372550129999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GdD-Is-Znt">
-                                                <rect key="frame" x="0.0" y="22.333333333333332" width="10" height="55.333333333333343"/>
+                                                <rect key="frame" x="0.0" y="22.333333333333336" width="50" height="85.666666666666657"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                         </subviews>
@@ -130,19 +130,19 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="xdn-FK-3rd">
-                                <rect key="frame" x="0.0" y="79.666666666666671" width="310" height="3.3333333333333286"/>
+                                <rect key="frame" x="0.0" y="110" width="378" height="17"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="qab-mg-Cga">
-                                        <rect key="frame" x="0.0" y="0.0" width="131.33333333333334" height="3.3333333333333335"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="131.33333333333334" height="17"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Total Goal:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Neu-Kk-xci">
-                                                <rect key="frame" x="0.0" y="0.0" width="84.333333333333329" height="3.3333333333333335"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="84.333333333333329" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10/30" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fcF-o1-wAe">
-                                                <rect key="frame" x="88.333333333333329" y="0.0" width="42.999999999999986" height="3.3333333333333335"/>
+                                                <rect key="frame" x="88.333333333333329" y="0.0" width="42.999999999999986" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -150,14 +150,14 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mAa-iY-HPI">
-                                        <rect key="frame" x="147.33333333333337" y="0.0" width="162.66666666666663" height="3.3333333333333335"/>
+                                        <rect key="frame" x="147.33333333333337" y="0.0" width="230.66666666666663" height="17"/>
                                         <subviews>
                                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.69999999999999996" translatesAutoresizingMaskIntoConstraints="NO" id="duN-cg-sfO">
-                                                <rect key="frame" x="0.0" y="0.0" width="111.33333333333333" height="3.3333333333333335"/>
+                                                <rect key="frame" x="0.0" y="6.6666666666666714" width="179.33333333333334" height="4"/>
                                                 <color key="tintColor" red="0.23137254901960785" green="0.27843137254901962" blue="0.32941176470588235" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                             </progressView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8vA-3b-HKh">
-                                                <rect key="frame" x="119.33333333333333" y="0.0" width="43.333333333333329" height="3.3333333333333335"/>
+                                                <rect key="frame" x="187.33333333333334" y="0.0" width="43.333333333333343" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -177,6 +177,7 @@
                     <constraint firstItem="4ax-XF-OSs" firstAttribute="leading" secondItem="yq1-ed-KzG" secondAttribute="leading" constant="30" id="ss9-Cx-XHM"/>
                 </constraints>
             </collectionViewCellContentView>
+            <size key="customSize" width="438" height="147"/>
             <userDefinedRuntimeAttributes>
                 <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                     <integer key="value" value="16"/>
@@ -192,7 +193,7 @@
                 <outlet property="tuesdayRing" destination="beu-mT-CwD" id="Qci-RF-3be"/>
                 <outlet property="wednesdayRing" destination="E8f-Qt-p0J" id="qro-oj-hD4"/>
             </connections>
-            <point key="canvasLocation" x="680.91603053435108" y="-33.450704225352112"/>
+            <point key="canvasLocation" x="832.06106870229007" y="-17.95774647887324"/>
         </collectionViewCell>
     </objects>
     <resources>

--- a/MomCare/StoryBoards/TriTrack/InternalStoryboards/Appointments.storyboard
+++ b/MomCare/StoryBoards/TriTrack/InternalStoryboards/Appointments.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oWn-ML-c53">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oWn-ML-c53">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -11,32 +11,32 @@
         <scene sceneID="SO7-kc-AcQ">
             <objects>
                 <tableViewController id="oWn-ML-c53" customClass="AllAppointmentsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="50" estimatedRowHeight="-1" sectionHeaderHeight="20" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="155-r4-zE4">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" rowHeight="50" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="155-r4-zE4">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AllAppointmentsTableViewCell" id="OT0-8f-6cT" customClass="AllAppointmentsTableViewCell" customModule="MomCare" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.333332061767578" width="393" height="50"/>
+                                <rect key="frame" x="20" y="55.333332061767578" width="353" height="50"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OT0-8f-6cT" id="71M-ff-Hm5">
-                                    <rect key="frame" x="0.0" y="0.0" width="393" height="50"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="353" height="50"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Swg-M9-le7">
-                                            <rect key="frame" x="20" y="5" width="353" height="40"/>
+                                            <rect key="frame" x="20" y="5" width="313" height="40"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="G72-Nt-3XD">
-                                                    <rect key="frame" x="0.0" y="0.0" width="353" height="40"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="313" height="40"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qhf-dF-tRq">
-                                                            <rect key="frame" x="0.0" y="0.0" width="353" height="20"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="313" height="20"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No notes provided" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="H0i-sS-wnZ">
-                                                            <rect key="frame" x="0.0" y="20" width="353" height="20"/>
+                                                            <rect key="frame" x="0.0" y="20" width="313" height="20"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <color key="textColor" systemColor="opaqueSeparatorColor"/>
                                                             <nil key="highlightedColor"/>
@@ -53,6 +53,7 @@
                                         <constraint firstItem="Swg-M9-le7" firstAttribute="leading" secondItem="71M-ff-Hm5" secondAttribute="leading" constant="20" id="voy-wQ-AuM"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
                                 <connections>
                                     <outlet property="notesLabel" destination="H0i-sS-wnZ" id="fv8-VZ-jGp"/>
                                     <outlet property="titleLabel" destination="Qhf-dF-tRq" id="5hM-pD-YqB"/>
@@ -77,6 +78,12 @@
         <image name="arrow.up.arrow.down" catalog="system" width="128" height="97"/>
         <systemColor name="opaqueSeparatorColor">
             <color red="0.77647058820000003" green="0.77647058820000003" blue="0.7843137255" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/MomCare/StoryBoards/TriTrack/InternalStoryboards/Reminders.storyboard
+++ b/MomCare/StoryBoards/TriTrack/InternalStoryboards/Reminders.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="O4E-30-vrW">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="O4E-30-vrW">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -10,26 +11,27 @@
         <scene sceneID="ijA-1Y-xCH">
             <objects>
                 <tableViewController storyboardIdentifier="AllRemindersTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="O4E-30-vrW" customClass="AllRemindersTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="Rdq-Lr-Sys">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="Rdq-Lr-Sys">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.9137254901960784" green="0.82745098039215681" blue="0.82745098039215681" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AllRemindersTableViewCell" id="Zx3-Yf-LfQ" customClass="AllRemindersTableViewCell" customModule="MomCare" customModuleProvider="target">
-                                <rect key="frame" x="20" y="55.333332061767578" width="353" height="44.666667938232422"/>
+                                <rect key="frame" x="20" y="55.333332061767578" width="353" height="50.333332061767578"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Zx3-Yf-LfQ" id="Fym-Cv-bcE">
-                                    <rect key="frame" x="0.0" y="0.0" width="353" height="44.666667938232422"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="353" height="50.333332061767578"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cgd-hl-l1v">
-                                            <rect key="frame" x="20" y="5" width="313" height="34.666666666666664"/>
+                                            <rect key="frame" x="3" y="8" width="330" height="34.333333333333336"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m3n-53-Jg1">
-                                                    <rect key="frame" x="0.0" y="0.0" width="271.66666666666669" height="34.666666666666657"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="288.66666666666669" height="34.333333333333336"/>
                                                     <subviews>
                                                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Xci-WO-IS9">
-                                                            <rect key="frame" x="0.0" y="0.0" width="49.666666666666664" height="34.666666666666664"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="49.666666666666664" height="34.333333333333336"/>
+                                                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" image="circle" catalog="system"/>
                                                             <connections>
@@ -37,7 +39,7 @@
                                                             </connections>
                                                         </button>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RnB-ud-DGN">
-                                                            <rect key="frame" x="49.666666666666686" y="0.0" width="222" height="34.666666666666664"/>
+                                                            <rect key="frame" x="49.666666666666657" y="0.0" width="238.99999999999997" height="34.333333333333336"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -45,7 +47,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YfC-5b-lkn">
-                                                    <rect key="frame" x="271.66666666666669" y="0.0" width="41.333333333333314" height="34.666666666666664"/>
+                                                    <rect key="frame" x="288.66666666666669" y="0.0" width="41.333333333333314" height="34.333333333333336"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -54,12 +56,13 @@
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="Cgd-hl-l1v" secondAttribute="bottom" constant="5" id="1Bb-5K-I4e"/>
-                                        <constraint firstItem="Cgd-hl-l1v" firstAttribute="leading" secondItem="Fym-Cv-bcE" secondAttribute="leading" constant="20" id="3LJ-wi-Tj7"/>
-                                        <constraint firstItem="Cgd-hl-l1v" firstAttribute="top" secondItem="Fym-Cv-bcE" secondAttribute="top" constant="5" id="73e-R1-rWF"/>
+                                        <constraint firstAttribute="bottom" secondItem="Cgd-hl-l1v" secondAttribute="bottom" constant="8" id="1Bb-5K-I4e"/>
+                                        <constraint firstItem="Cgd-hl-l1v" firstAttribute="leading" secondItem="Fym-Cv-bcE" secondAttribute="leading" constant="3" id="3LJ-wi-Tj7"/>
+                                        <constraint firstItem="Cgd-hl-l1v" firstAttribute="top" secondItem="Fym-Cv-bcE" secondAttribute="top" constant="8" id="73e-R1-rWF"/>
                                         <constraint firstAttribute="trailing" secondItem="Cgd-hl-l1v" secondAttribute="trailing" constant="20" id="ywa-LR-G0f"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="button" destination="Xci-WO-IS9" id="j4w-hL-8rL"/>
                                     <outlet property="relativeTimeLabel" destination="YfC-5b-lkn" id="cqa-Zg-wwC"/>
@@ -80,5 +83,8 @@
     </scenes>
     <resources>
         <image name="circle" catalog="system" width="128" height="123"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/MomCare/StoryBoards/TriTrack/InternalStoryboards/Symptoms.storyboard
+++ b/MomCare/StoryBoards/TriTrack/InternalStoryboards/Symptoms.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="n3o-1m-7wH">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="n3o-1m-7wH">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -10,40 +11,41 @@
         <scene sceneID="s3O-1e-cIA">
             <objects>
                 <tableViewController id="n3o-1m-7wH" customClass="AllSymptomsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="s0a-4P-tlZ">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="s0a-4P-tlZ">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="0.91372549020000005" green="0.82745098039999998" blue="0.82745098039999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AllSymptomsTableViewCell" id="qad-tw-Rof" customClass="AllSymptomsTableViewCell" customModule="MomCare" customModuleProvider="target">
-                                <rect key="frame" x="20" y="55.333332061767578" width="353" height="66"/>
+                                <rect key="frame" x="20" y="55.333332061767578" width="353" height="75.666664123535156"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qad-tw-Rof" id="NSc-1q-ljQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="353" height="66"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="353" height="75.666664123535156"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kw8-Pr-crA">
-                                            <rect key="frame" x="20" y="5" width="313" height="56"/>
+                                            <rect key="frame" x="15" y="7.9999999999999964" width="323" height="59.666666666666657"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4OI-vs-aVy">
-                                                    <rect key="frame" x="0.0" y="0.0" width="41.333333333333336" height="56"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="31.333333333333332" height="59.666666666666664"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <datePicker contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" datePickerMode="dateAndTime" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="IGz-Ci-HJi">
-                                                    <rect key="frame" x="41.333333333333343" y="0.0" width="271.66666666666663" height="56"/>
+                                                    <rect key="frame" x="31.333333333333343" y="0.0" width="291.66666666666663" height="59.666666666666664"/>
                                                 </datePicker>
                                             </subviews>
                                         </stackView>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="kw8-Pr-crA" firstAttribute="top" secondItem="NSc-1q-ljQ" secondAttribute="top" constant="5" id="3jp-ee-xsk"/>
-                                        <constraint firstAttribute="bottom" secondItem="kw8-Pr-crA" secondAttribute="bottom" constant="5" id="SUL-tw-rMb"/>
-                                        <constraint firstItem="kw8-Pr-crA" firstAttribute="leading" secondItem="NSc-1q-ljQ" secondAttribute="leading" constant="20" id="XiT-5X-yUS"/>
-                                        <constraint firstAttribute="trailing" secondItem="kw8-Pr-crA" secondAttribute="trailing" constant="20" id="Zlx-09-Hjo"/>
+                                        <constraint firstItem="kw8-Pr-crA" firstAttribute="top" secondItem="NSc-1q-ljQ" secondAttribute="top" constant="8" id="3jp-ee-xsk"/>
+                                        <constraint firstAttribute="bottom" secondItem="kw8-Pr-crA" secondAttribute="bottom" constant="8" id="SUL-tw-rMb"/>
+                                        <constraint firstItem="kw8-Pr-crA" firstAttribute="leading" secondItem="NSc-1q-ljQ" secondAttribute="leading" constant="15" id="XiT-5X-yUS"/>
+                                        <constraint firstAttribute="trailing" secondItem="kw8-Pr-crA" secondAttribute="trailing" constant="15" id="Zlx-09-Hjo"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <outlet property="dateTimePicker" destination="IGz-Ci-HJi" id="WsL-Gg-fPY"/>
                                     <outlet property="titleLabel" destination="4OI-vs-aVy" id="6UR-wf-bTS"/>
@@ -61,4 +63,9 @@
             <point key="canvasLocation" x="-54" y="-14"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/MomCare/StoryBoards/TriTrack/TriTrack.storyboard
+++ b/MomCare/StoryBoards/TriTrack/TriTrack.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="rhV-Jn-uGw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="rhV-Jn-uGw">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,14 +19,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W3X-Gk-qCf" userLabel="CalendarVIew">
-                                <rect key="frame" x="0.0" y="103" width="393" height="90"/>
+                                <rect key="frame" x="0.0" y="162" width="393" height="90"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="90" id="QHZ-jG-v0C"/>
                                 </constraints>
                             </view>
                             <view autoresizesSubviews="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5rT-SM-LqO">
-                                <rect key="frame" x="10" y="208" width="373" height="624"/>
+                                <rect key="frame" x="10" y="267" width="373" height="565"/>
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="huh-qS-KT6">
                                         <rect key="frame" x="20" y="20" width="333" height="32"/>
@@ -41,21 +41,21 @@
                                         </connections>
                                     </segmentedControl>
                                     <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cXJ-RZ-JqR" userLabel="MeAndBabyContainerView">
-                                        <rect key="frame" x="0.0" y="61" width="373" height="553"/>
+                                        <rect key="frame" x="0.0" y="61" width="373" height="494"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <segue destination="wUm-Dj-2YZ" kind="embed" id="zNm-78-6RY"/>
                                         </connections>
                                     </containerView>
                                     <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Whb-9z-qyg" userLabel="EventsContainerView">
-                                        <rect key="frame" x="0.0" y="61" width="373" height="553"/>
+                                        <rect key="frame" x="0.0" y="61" width="373" height="494"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <segue destination="dzv-zm-WHV" kind="embed" identifier="embedShowEventsViewController" id="aP2-vi-shQ"/>
                                         </connections>
                                     </containerView>
                                     <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AVa-q4-rLC" userLabel="SymptomsContainerView">
-                                        <rect key="frame" x="0.0" y="61" width="373" height="553"/>
+                                        <rect key="frame" x="0.0" y="61" width="373" height="494"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <segue destination="CyI-l2-NOD" kind="embed" identifier="embedShowSymptomsViewController" id="mrf-jO-ece"/>
@@ -97,11 +97,13 @@
                     <navigationItem key="navigationItem" title="TriTrack" id="c7G-bw-x0Q">
                         <rightBarButtonItems>
                             <barButtonItem systemItem="add" id="0aU-xb-WS9">
+                                <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <segue destination="NWv-1C-IJ6" kind="presentation" identifier="segueShowTriTrackAddEventViewController" id="o6w-7A-riG"/>
                                 </connections>
                             </barButtonItem>
                             <barButtonItem systemItem="refresh" id="FiT-8b-dc4">
+                                <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <connections>
                                     <action selector="refreshButtonTapped:" destination="Y6W-OH-hqX" id="bGx-6p-eit"/>
                                 </connections>
@@ -130,7 +132,7 @@
                     <tabBarItem key="tabBarItem" title="TriTrack" image="calendar" catalog="system" id="jPg-uU-miX"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="EYN-8Y-Y50">
-                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <rect key="frame" x="0.0" y="118" width="393" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -150,7 +152,7 @@
             <objects>
                 <viewController storyboardIdentifier="TriTrackAddEventViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="fms-3k-5Rz" customClass="TriTrackAddEventViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="PZR-ss-lj8">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="783"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Js8-bI-4Nb">
@@ -164,21 +166,21 @@
                                 </connections>
                             </segmentedControl>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L8e-yd-3fo" userLabel="ReminderContainerView">
-                                <rect key="frame" x="0.0" y="87" width="393" height="755"/>
+                                <rect key="frame" x="0.0" y="87" width="393" height="696"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <segue destination="zZe-X7-vho" kind="embed" identifier="embedShowAddReminderTableViewController" id="k8l-Ko-djd"/>
                                 </connections>
                             </containerView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OaV-nn-bAL" userLabel="EventContainerView">
-                                <rect key="frame" x="0.0" y="87" width="393" height="755"/>
+                                <rect key="frame" x="0.0" y="87" width="393" height="696"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <segue destination="gut-L1-QDM" kind="embed" identifier="embedShowAddEventTableViewController" id="nzd-B2-nhw"/>
                                 </connections>
                             </containerView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pUQ-WS-dqk" userLabel="SymptomsContainerView">
-                                <rect key="frame" x="0.0" y="87" width="393" height="755"/>
+                                <rect key="frame" x="0.0" y="87" width="393" height="696"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <connections>
                                     <segue destination="jOI-Vi-XpI" kind="embed" identifier="embedShowAddSymptomsTableViewController" id="Vfv-To-BoQ"/>
@@ -234,7 +236,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="AddEventTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="gut-L1-QDM" customClass="AddEventTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="50" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="f5v-EN-djp">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="696"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -545,7 +547,7 @@
             <objects>
                 <tableViewController id="jOI-Vi-XpI" customClass="AddSymptomsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="50" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="Rxe-pZ-3gH">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="696"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -657,7 +659,7 @@
             <objects>
                 <tableViewController id="zZe-X7-vho" customClass="AddReminderTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="insetGrouped" separatorStyle="default" rowHeight="50" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="hgS-1U-2Ah">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="755"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="696"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <sections>
@@ -834,14 +836,14 @@
             <objects>
                 <viewController id="dzv-zm-WHV" customClass="EventsViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="65w-PH-84r">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="553"/>
+                        <rect key="frame" x="0.0" y="0.0" width="373" height="494"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="qR8-RI-IHD">
-                                <rect key="frame" x="0.0" y="59" width="373" height="460"/>
+                                <rect key="frame" x="0.0" y="118" width="373" height="342"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="wEr-zr-mK6">
-                                        <rect key="frame" x="0.0" y="0.0" width="373" height="230"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="wEr-zr-mK6">
+                                        <rect key="frame" x="0.0" y="0.0" width="373" height="171"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WMk-uJ-eYx">
                                                 <rect key="frame" x="0.0" y="0.0" width="373" height="23"/>
@@ -854,6 +856,7 @@
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="khx-Is-1EQ">
                                                         <rect key="frame" x="333.33333333333331" y="0.0" width="39.666666666666686" height="23"/>
+                                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="chevron.right" catalog="system"/>
                                                         <connections>
@@ -863,14 +866,14 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3cd-bA-O7v">
-                                                <rect key="frame" x="0.0" y="24" width="373" height="1"/>
+                                                <rect key="frame" x="0.0" y="28" width="373" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="Xdp-DW-C1c"/>
                                                 </constraints>
                                             </view>
                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qKN-fw-oqP">
-                                                <rect key="frame" x="0.0" y="26" width="373" height="204"/>
+                                                <rect key="frame" x="0.0" y="34" width="373" height="137"/>
                                                 <connections>
                                                     <segue destination="uzu-3k-7qw" kind="embed" identifier="embedShowAppointmentsTableViewController" id="5M3-AY-DFd"/>
                                                 </connections>
@@ -878,19 +881,20 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="idM-cQ-IIY">
-                                        <rect key="frame" x="0.0" y="230" width="373" height="230"/>
+                                        <rect key="frame" x="0.0" y="171" width="373" height="171"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pXQ-yP-CS6">
-                                                <rect key="frame" x="0.0" y="0.0" width="373" height="29.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="373" height="23"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="    Reminders" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyn-LG-mz1">
-                                                        <rect key="frame" x="0.0" y="0.0" width="333.33333333333331" height="29.333333333333332"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="333.33333333333331" height="23"/>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0TG-0u-zZd">
-                                                        <rect key="frame" x="333.33333333333331" y="0.0" width="39.666666666666686" height="29.333333333333332"/>
+                                                        <rect key="frame" x="333.33333333333331" y="0.0" width="39.666666666666686" height="23"/>
+                                                        <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" image="chevron.right" catalog="system"/>
                                                         <connections>
@@ -900,14 +904,14 @@
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Teu-dq-0o1">
-                                                <rect key="frame" x="0.0" y="34.333333333333314" width="373" height="1"/>
+                                                <rect key="frame" x="0.0" y="28" width="373" height="1"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="j97-F0-EaG"/>
                                                 </constraints>
                                             </view>
                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pGX-Rc-gde">
-                                                <rect key="frame" x="0.0" y="40.3333333333333" width="373" height="189.66666666666663"/>
+                                                <rect key="frame" x="0.0" y="34" width="373" height="137"/>
                                                 <connections>
                                                     <segue destination="WEG-uo-kp3" kind="embed" identifier="embedShowRemindersTableViewController" id="ihj-17-XEo"/>
                                                 </connections>
@@ -1075,7 +1079,7 @@
             <objects>
                 <tableViewController id="uzu-3k-7qw" customClass="AppointmentsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="none" sectionIndexMinimumDisplayRowCount="1" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="1" estimatedSectionFooterHeight="-1" id="lRt-Ci-B8t">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="204"/>
+                        <rect key="frame" x="0.0" y="0.0" width="373" height="137"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
@@ -1136,7 +1140,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="RemindersTableViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="WEG-uo-kp3" customClass="RemindersTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="EVQ-mH-9Kv">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="189.66666666666666"/>
+                        <rect key="frame" x="0.0" y="0.0" width="373" height="137"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
@@ -1158,6 +1162,7 @@
                                                             <constraints>
                                                                 <constraint firstAttribute="width" secondItem="S7r-5C-8oi" secondAttribute="height" id="eC4-uv-4gt"/>
                                                             </constraints>
+                                                            <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <state key="normal" title="Button"/>
                                                             <buttonConfiguration key="configuration" style="plain" image="circle" catalog="system" cornerStyle="capsule">
                                                                 <backgroundConfiguration key="background" strokeWidth="0.0" strokeOutset="0.0">
@@ -1225,11 +1230,11 @@
             <objects>
                 <viewController id="CyI-l2-NOD" customClass="SymptomsViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="n5q-oD-6av">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="553"/>
+                        <rect key="frame" x="0.0" y="0.0" width="373" height="494"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="iml-6n-71x">
-                                <rect key="frame" x="0.0" y="59" width="373" height="494"/>
+                                <rect key="frame" x="0.0" y="118" width="373" height="376"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yUL-iK-XXh">
                                         <rect key="frame" x="0.0" y="0.0" width="373" height="23"/>
@@ -1242,6 +1247,7 @@
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PuN-Oc-QGQ">
                                                 <rect key="frame" x="333.33333333333331" y="0.0" width="39.666666666666686" height="23"/>
+                                                <color key="tintColor" red="0.57254901960000004" green="0.26274509800000001" blue="0.31372549020000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Button"/>
                                                 <buttonConfiguration key="configuration" style="plain" image="chevron.right" catalog="system"/>
                                                 <connections>
@@ -1258,7 +1264,7 @@
                                         </constraints>
                                     </view>
                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="33E-CX-Qv3">
-                                        <rect key="frame" x="0.0" y="34" width="373" height="460"/>
+                                        <rect key="frame" x="0.0" y="34" width="373" height="342"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <segue destination="f6P-AY-aDg" kind="embed" identifier="embedShowSymptomsTabelViewController" id="0oS-vp-Rrs"/>
@@ -1286,7 +1292,7 @@
             <objects>
                 <tableViewController id="f6P-AY-aDg" customClass="SymptomsTableViewController" customModule="MomCare" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="insetGrouped" separatorStyle="none" sectionIndexMinimumDisplayRowCount="1" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" estimatedSectionHeaderHeight="-1" sectionFooterHeight="18" estimatedSectionFooterHeight="-1" id="3fR-3A-ydM">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="460"/>
+                        <rect key="frame" x="0.0" y="0.0" width="373" height="342"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
@@ -1351,7 +1357,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kPL-q1-TaW" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="xIb-GY-APT">
-                        <rect key="frame" x="0.0" y="0.0" width="373" height="44"/>
+                        <rect key="frame" x="0.0" y="59" width="373" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -1373,16 +1379,16 @@
             <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGray6Color">
-            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
## Summary by Sourcery

Overhaul the breathing exercise screen with a fully programmatic UI featuring animated gradients, dynamic circle-petal animations, instructional and timer labels, and comprehensive start/pause/resume/stop controls. Standardize UI accent color across dashboard and profile pages and replace network fetch with a local mock for exercises.

New Features:
- Redesign the breathing player to use animated gradient backgrounds and circle layers for inhale/hold/exhale animations with integrated timers and assuring completion message
- Implement a start/pause/resume/stop state machine with programmatic controls and countdown timers
- Replace remote exercise fetch with a local mock data stub for development

Enhancements:
- Standardize accent color (#924350) on the dashboard profile icon and profile view controllers
- Update dashboard profile button to use an SF Symbol with tint and adjust layout constraints
- Simplify exercise fetching logic by removing redundant existence checks