### PR TITLE
Update DietaryPreference enum to limit options

### DIFF
--- a/MomCare+/Common/Static/ModelSpecific/DietaryPreferenceData.swift
+++ b/MomCare+/Common/Static/ModelSpecific/DietaryPreferenceData.swift
@@ -10,7 +10,7 @@ public enum DietaryPreference: String, Codable, CaseIterable, Sendable {
     case nonVegetarian = "Non-Vegetarian"
     case vegan = "Vegan"
 
-    // TODO: Backend does does support more than 3 pref. @rtk-rnjn
+    // TODO: Backend currently supports a maximum of 3 dietary preferences. Add a backend ticket/issue ID here for future follow-up.
     // case pescetarian = "Pescetarian"
     // case flexitarian = "Flexitarian"
     // case glutenFree = "Gluten-Free"


### PR DESCRIPTION
Commented out additional dietary preference cases due to backend limitations.

## Summary by Sourcery

Restrict available dietary preference options in the shared enum to the three backend-supported values plus a generic none option.

Bug Fixes:
- Align dietary preference options with current backend support by disabling unsupported enum cases.

Enhancements:
- Document backend limitation on dietary preferences and retain unsupported options as commented-out placeholders for future use.