### PR TITLE
Make account delete async and clear auth state

### DIFF
--- a/MomCare+/Common/DataHandler/AuthenticationService.swift
+++ b/MomCare+/Common/DataHandler/AuthenticationService.swift
@@ -214,8 +214,12 @@ final class AuthenticationService: ObservableObject {
     }
 
     @discardableResult
-    func delete() async throws -> NetworkResponse<ServerMessage> {
-        try await NetworkManager.shared.delete(url: Endpoint.delete.urlString, headers: AuthenticationService.authorizationHeaders)
+    func delete() async throws -> NetworkResponse<Bool> {
+        let networkResponse: NetworkResponse<Bool> = try await NetworkManager.shared.delete(url: Endpoint.delete.urlString, headers: AuthenticationService.authorizationHeaders)
+        if networkResponse.success {
+            dropCredentials()
+        }
+        return networkResponse
     }
 
     func googleLogin(idToken: String, existingEmailAddress: String? = nil) async throws -> NetworkResponse<TokenPair> {
@@ -283,6 +287,7 @@ final class AuthenticationService: ObservableObject {
         database.delete(ValidDatabaseKeys.accessTokenExpiresAtTimestamp.rawValue)
 
         userModel?._id = ""
+        userModel = nil
     }
 
     private func loginWithApple(token: String) async throws -> NetworkResponse<TokenPair> {

--- a/MomCare+/MomCare+/Views/DashboardScreens/ProfileScreens/AccountManagementView.swift
+++ b/MomCare+/MomCare+/Views/DashboardScreens/ProfileScreens/AccountManagementView.swift
@@ -29,7 +29,9 @@ struct AccountManagementView: View {
         .navigationBarTitleDisplayMode(.inline)
         .alert("Delete Account?", isPresented: $showDeleteAlert) {
             Button("Delete", role: .destructive) {
-                deleteAccount()
+                Task {
+                    await deleteAccount()
+                }
             }
 
             Button("Cancel", role: .cancel) {}
@@ -42,12 +44,9 @@ struct AccountManagementView: View {
     // MARK: Private
 
     @State private var showDeleteAlert = false
+    @EnvironmentObject private var authenticationService: AuthenticationService
 
-    private func deleteAccount() {
-        print("Account deleted")
+    private func deleteAccount() async {
+        _ = try? await authenticationService.delete()
     }
-}
-
-#Preview {
-    AccountManagementView()
 }


### PR DESCRIPTION
Change AuthenticationService.delete to return NetworkResponse<Bool>, call dropCredentials() when deletion succeeds, and explicitly nil out userModel. Update AccountManagementView to perform the delete call asynchronously (wrap in Task), add AuthenticationService as an EnvironmentObject, and make deleteAccount async. Removes the preview and ensures local credentials are cleared after a successful server-side account deletion.

## Summary by Sourcery

Make account deletion asynchronous and ensure local authentication state is cleared when a server-side delete succeeds.

Bug Fixes:
- Ensure credentials and user model are cleared after successful account deletion.

Enhancements:
- Update account management UI to perform account deletion via the shared authentication service asynchronously.