### PR TITLE
Add total completion duration & UI updates

### DIFF
--- a/MomCare+/Common/Models/ExerciseModel.swift
+++ b/MomCare+/Common/Models/ExerciseModel.swift
@@ -128,4 +128,47 @@ struct UserExerciseModel: Codable, Sendable, Identifiable, Equatable {
             return count
         }
     }
+
+    static func totalDurationCompletion(from userExercises: [UserExerciseModel]) async -> TimeInterval {
+        await withTaskGroup(of: TimeInterval.self) { group in
+            for exercise in userExercises {
+                group.addTask {
+                    let percentage = await exercise.completionPercentage
+                    guard let exerciseModel = await exercise.exerciseModel else { return 0 }
+                    return percentage * exerciseModel.videoDurationSeconds
+                }
+            }
+
+            var totalDuration: TimeInterval = 0
+
+            for await duration in group {
+                totalDuration += duration
+            }
+
+            return totalDuration
+        }
+    }
+
+    static func totalDurationCompletionPercent(from userExercises: [UserExerciseModel]) async -> Double {
+        let totalDuration = await totalDurationCompletion(from: userExercises)
+        let totalPossibleDuration = await withTaskGroup(of: TimeInterval.self) { group in
+            for exercise in userExercises {
+                group.addTask {
+                    guard let exerciseModel = await exercise.exerciseModel else { return 0 }
+                    return exerciseModel.videoDurationSeconds
+                }
+            }
+
+            var total: TimeInterval = 0
+
+            for await duration in group {
+                total += duration
+            }
+
+            return total
+        }
+
+        guard totalPossibleDuration > 0 else { return 0 }
+        return min(totalDuration / totalPossibleDuration, 1.0)
+    }
 }

--- a/MomCare+/MomCare+/Views/DashboardScreens/DashboardSnippets/DashboardExerciseCardView.swift
+++ b/MomCare+/MomCare+/Views/DashboardScreens/DashboardSnippets/DashboardExerciseCardView.swift
@@ -4,14 +4,15 @@ struct DashboardExerciseCard: View {
 
     // MARK: Internal
 
-    let minutes: Double
+    @State var seconds: Double = 0
+
     let calories: Int
 
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 18) {
                 ExerciseRow(color: .red, icon: "figure.walk", value: "\(Int(healthKitHandler.currentSteps)) Steps")
-                ExerciseRow(color: .green, icon: "timer", value: "\(Int(minutes)) Min")
+                ExerciseRow(color: .green, icon: "timer", value: displaySeconds)
                 ExerciseRow(color: .orange, icon: "flame.fill", value: "\(Int(calories)) Kcal")
             }
 
@@ -28,15 +29,40 @@ struct DashboardExerciseCard: View {
         .padding(.leading, 3)
         .background(Color("secondaryAppColor"))
         .dashboardCardStyle()
-        .task {
-            await healthKitHandler.fetchTotalDuration()
-            let completedDuration = healthKitHandler.userExercises.reduce(0) { $0 + $1.videoDurationCompletedSeconds }
+        .onChange(of: healthKitHandler.userExercises) {
+            Task {
+                await healthKitHandler.fetchTotalDuration()
+                exerciseProgress = await UserExerciseModel.totalDurationCompletionPercent(from: healthKitHandler.userExercises)
+            }
+        }
+        .onChange(of: healthKitHandler.userExercises) {
+            Task {
+                let totalCompletion = await UserExerciseModel.totalDurationCompletion(from: healthKitHandler.userExercises)
+                seconds = totalCompletion / 60
 
-            exerciseProgress = healthKitHandler.totalExerciseDuration / completedDuration
+                let measurement = Measurement(value: seconds, unit: UnitDuration.seconds)
+
+                let formatter = MeasurementFormatter()
+                formatter.unitOptions = .providedUnit
+
+                let numberFormatter = NumberFormatter()
+                numberFormatter.maximumFractionDigits = 2
+
+                formatter.numberFormatter = numberFormatter
+
+                displaySeconds = formatter.string(from: measurement)
+            }
+        }
+        .task {
+            if let networkResponse = try? await ContentService.shared.fetchUserExercises(), let userExercises = networkResponse.data {
+                healthKitHandler.userExercises = userExercises
+            }
         }
     }
 
     // MARK: Private
+
+    @State private var displaySeconds: String = "- min"
 
     @EnvironmentObject private var healthKitHandler: HealthKitHandler
 

--- a/MomCare+/MomCare+/Views/DashboardScreens/DashboardView.swift
+++ b/MomCare+/MomCare+/Views/DashboardScreens/DashboardView.swift
@@ -96,7 +96,6 @@ struct DashboardView: View {
             }
 
             DashboardExerciseCard(
-                minutes: healthKitHandler.minutes,
                 calories: healthKitHandler.caloriesBurned
             )
             .padding(.horizontal)
@@ -151,7 +150,6 @@ struct DashboardView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var selectedEvent: EKCalendarItemWrapper?
-
 }
 
 extension View {


### PR DESCRIPTION
Add concurrent helpers to UserExerciseModel to compute total completed video duration and completion percent (totalDurationCompletion and totalDurationCompletionPercent) using TaskGroup. Update DashboardExerciseCard to remove the minutes prop, introduce seconds and displaySeconds state, and format the aggregated completion duration for display; compute exerciseProgress and formatted duration in onChange handlers when healthKitHandler.userExercises changes. Also load user exercises on task and remove the minutes parameter from DashboardView. These changes enable displaying the accumulated completed exercise time and percent based on fetched user exercise data.

## Summary by Sourcery

Compute aggregate exercise completion duration and percentage from user exercises and surface them on the dashboard exercise card using fetched user exercise data.

New Features:
- Add async helpers on UserExerciseModel to calculate total completed video duration and overall completion percentage across exercises.
- Display aggregated completed exercise time on the dashboard exercise card based on user exercise data fetched from the backend.

Enhancements:
- Update dashboard exercise card to derive progress and formatted duration from userExercises changes instead of relying on a passed-in minutes value.
- Trigger loading of user exercises on dashboard task and remove the minutes parameter from DashboardView and DashboardExerciseCard.